### PR TITLE
wasm-base feature to have a native noir backend using the WASM barretenberg 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 
-acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
+acvm = { git = "https://github.com/noir-lang/noir" }
 barretenberg_wrapper = { optional = true, git = "https://github.com/AztecProtocol/barretenberg", rev = "804c7dcf21111acd1302a768a8fa2f453dcec50f" }
 
 sha2 = "0.9.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,10 @@ wasm-bindgen = { version = "*", optional = true }
 js-sys = { version = "0.3.55", optional = true }
 getrandom = { version = "0.2.4", features = ["js"], optional = true }
 
-[dev-dependencies]
 tempfile = "3.2.0"
 
 [features]
-default = ["wasm"]
+default = ["sys"]
 wasm = [
     "acvm/bn254",
     "wasmer/js-default",

--- a/src/acvm_interop/mod.rs
+++ b/src/acvm_interop/mod.rs
@@ -1,9 +1,7 @@
-#[cfg(feature = "sys")]
+
 pub mod proof_system;
 pub mod pwg;
-#[cfg(feature = "sys")]
 mod smart_contract;
 pub struct Plonk;
 
-#[cfg(feature = "sys")]
 impl acvm::Backend for Plonk {}

--- a/src/acvm_interop/pwg/merkle.rs
+++ b/src/acvm_interop/pwg/merkle.rs
@@ -33,7 +33,7 @@ fn fetch_root(db: &sled::Db) -> FieldElement {
         .get("ROOT".as_bytes())
         .unwrap()
         .expect("merkle root should always be present");
-    FieldElement::from_be_bytes_reduce(&value.to_vec())
+    FieldElement::from_be_bytes_reduce(&value)
 }
 fn insert_depth(db: &mut sled::Db, value: u32) {
     db.insert("DEPTH".as_bytes(), &value.to_be_bytes()).unwrap();
@@ -68,14 +68,14 @@ fn insert_preimage(db: &mut sled::Db, index: u32, value: Vec<u8>) {
     let tree = db.open_tree("preimages").unwrap();
 
     let index = index as u128;
-    tree.insert(&index.to_be_bytes(), value).unwrap();
+    tree.insert(index.to_be_bytes(), value).unwrap();
 }
 
 fn fetch_preimage(db: &sled::Db, index: usize) -> Vec<u8> {
     let tree = db.open_tree("preimages").unwrap();
 
     let index = index as u128;
-    tree.get(&index.to_be_bytes())
+    tree.get(index.to_be_bytes())
         .unwrap()
         .map(|i_vec| i_vec.to_vec())
         .unwrap()
@@ -84,9 +84,9 @@ fn fetch_hash(db: &sled::Db, index: usize) -> FieldElement {
     let tree = db.open_tree("hashes").unwrap();
     let index = index as u128;
 
-    tree.get(&index.to_be_bytes())
+    tree.get(index.to_be_bytes())
         .unwrap()
-        .map(|i_vec| FieldElement::from_be_bytes_reduce(&i_vec.to_vec()))
+        .map(|i_vec| FieldElement::from_be_bytes_reduce(&i_vec))
         .unwrap()
 }
 
@@ -94,7 +94,7 @@ fn insert_hash(db: &mut sled::Db, index: u32, hash: FieldElement) {
     let tree = db.open_tree("hashes").unwrap();
     let index = index as u128;
 
-    tree.insert(&index.to_be_bytes(), hash.to_bytes()).unwrap();
+    tree.insert(index.to_be_bytes(), hash.to_bytes()).unwrap();
 }
 
 fn find_hash_from_value(db: &sled::Db, leaf_value: &FieldElement) -> Option<u128> {

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "sys")]
 use crate::barretenberg_rs::composer::StandardComposer;
 use acvm::acir::circuit::Circuit;
 
@@ -6,11 +7,17 @@ use acvm::SmartContract;
 use super::Plonk;
 
 impl SmartContract for Plonk {
+    #[cfg(feature = "sys")]
     fn eth_contract_from_cs(&self, circuit: Circuit) -> String {
         let constraint_system = crate::serialise_circuit(&circuit);
 
         let mut composer = StandardComposer::new(constraint_system);
 
         composer.smart_contract()
+    }
+
+    #[cfg(feature = "wasm-base")]
+    fn eth_contract_from_cs(&self, circuit: Circuit) -> String {
+        todo!();
     }
 }

--- a/src/barretenberg_wasm/mod.rs
+++ b/src/barretenberg_wasm/mod.rs
@@ -97,7 +97,7 @@ impl Default for Barretenberg {
 fn load_module() -> (Module, Store) {
     let store = Store::default();
 
-    let module = Module::new(&store, &WASM).unwrap();
+    let module = Module::new(&store, WASM).unwrap();
     (module, store)
 }
 

--- a/src/serialiser/mod.rs
+++ b/src/serialiser/mod.rs
@@ -158,7 +158,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         merkle_membership_constraints.push(constraint);
                     }
                     OPCODE::SchnorrVerify => {
-                        let mut inputs_iter = gadget_call.inputs.iter().peekable();
+                        let mut inputs_iter = gadget_call.inputs.iter();
 
                         // pub_key_x
                         let public_key_x = {
@@ -246,7 +246,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         hash_to_field_constraints.push(hash_to_field_constraint);
                     }
                     OPCODE::EcdsaSecp256k1 => {
-                        let mut inputs_iter = gadget_call.inputs.iter().peekable();
+                        let mut inputs_iter = gadget_call.inputs.iter();
 
                         // public key x
                         let mut public_key_x = [0i32; 32];


### PR DESCRIPTION
Dummy proof and verification for now, circuit and witnesses are serialized to disk so that noir-cli-js will be able to use them to generate the proof.