### PR TITLE
re-download broken crs

### DIFF
--- a/src/barretenberg_rs/crs.rs
+++ b/src/barretenberg_rs/crs.rs
@@ -26,7 +26,12 @@ impl CRS {
             download_crs(transcript_location());
         }
 
-        let crs = read_crs(transcript_location());
+        // Read CRS, if it's incomplete, download it
+        let mut crs = read_crs(transcript_location());
+        if crs.len() != G2_END {
+            download_crs(transcript_location());
+            crs = read_crs(transcript_location());
+        }
 
         let g1_data = crs[G1_START..=g1_end].to_vec();
         let g2_data = crs[G2_START..=G2_END].to_vec();
@@ -58,9 +63,9 @@ fn read_crs(path: std::path::PathBuf) -> Vec<u8> {
 // XXX: Below is the logic to download the CRS if it is not already present
 
 pub fn download_crs(mut path_to_transcript: std::path::PathBuf) {
+    // Remove old crs
     if path_to_transcript.exists() {
-        println!("File already exists {:?}", path_to_transcript);
-        return;
+        let _ = std::fs::remove_file(path_to_transcript.as_path());
     }
     // Pop off the transcript component to get just the directory
     path_to_transcript.pop();


### PR DESCRIPTION
If downloading CRS failed(e.g. network interruption), there will be an incomplete CRS file, and resulting `nargo prove` failed.
```shell=
thread 'main' panicked at 'range end index 1052 out of range for slice of length 329', /Users/runner/.cargo/git/checkouts/aztec_backend-a697fb631cbad807/d8e63d7/common/src/crs.rs:31:23
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::slice::index::slice_end_index_len_fail_rt
   3: core::slice::index::slice_end_index_len_fail
   4: common::crs::CRS::new
   5: barretenberg_wasm::composer::StandardComposer::new
   6: barretenberg_wasm::acvm_interop::proof_system::<impl acvm::ProofSystemCompiler for barretenberg_wasm::acvm_interop::Plonk>::prove_with_meta
   7: nargo::cli::prove_cmd::run
   8: nargo::cli::start_cli
```

This PR fix this by re-download CRS when it is incomplete.