### PR TITLE
Update bb commit reference to renamed aztec-2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/AztecProtocol/barretenberg?rev=804c7dcf21111acd1302a768a8fa2f453dcec50f#804c7dcf21111acd1302a768a8fa2f453dcec50f"
+source = "git+https://github.com/AztecProtocol/aztec-2.0?rev=804c7dcf21111acd1302a768a8fa2f453dcec50f#804c7dcf21111acd1302a768a8fa2f453dcec50f"
 dependencies = [
  "cmake",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 
 acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
-barretenberg_wrapper = { git = "https://github.com/AztecProtocol/barretenberg", rev = "804c7dcf21111acd1302a768a8fa2f453dcec50f" }
+barretenberg_wrapper = { git = "https://github.com/AztecProtocol/aztec-2.0", rev = "804c7dcf21111acd1302a768a8fa2f453dcec50f" }
 
 sha2 = "0.9.3"
 blake2 = "0.9.1"


### PR DESCRIPTION
This branch is just here to back port the Noir backend as we update to the new barretenberg repository. The old repo was renamed and we need this new commit reference in order for the main Noir repo to pass its CI build. 