### PR TITLE
Update commit to bb_wrapper to fix hash_to_field

### DIFF
--- a/barretenberg_static_lib/Cargo.toml
+++ b/barretenberg_static_lib/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 common = { path = "../common" }
-barretenberg_wrapper = { git = "https://github.com/noir-lang/aztec-connect", rev = "d79bbda6ec1fae6650256479a5f044843912ae2c" }
+barretenberg_wrapper = { git = "https://github.com/noir-lang/aztec-connect", rev = "6a810068375c90c00e2ca795823ff43ee8ebd79b" }
 
 sha2 = "0.9.3"
 blake2 = "0.9.1"


### PR DESCRIPTION
In the `aztec_backend` when setting up the constraint inputs and outputs we use `assignment.fetch_nearest_bytes` which reverses the byte array returned by `to_bytes`. The method `fetch_nearest_bytes` can be found [here](https://github.com/noir-lang/noir/blob/dff8f393706c102055e78b4d97df207d73640eee/crates/noir_field/src/generic_ark.rs#L257). While its usage in the `aztec_backend` acvm_interop can be found [here](https://github.com/noir-lang/aztec_backend/blob/e3d4c7974dee07f17c9768f0e3f35e84ead175d3/barretenberg_static_lib/src/acvm_interop/pwg/gadget_call.rs#L124). When creating the hash to field constraints in C++ we treat the field inputs the same as u8 inputs, however, inside of `fetch_nearest_bytes` we are reversing the byte array we are planning to hash. This is fine to use for u8 inputs (which we do for foreign blake2s OPCODE) but for larger datatypes such as Fields we are reversing the endianness. This PR simply follows what we do in the Rust acvm_interop so that the inputs to the hash function used in Rust and the C++ match. However, a refactor could be done to make endianness more explicit throughout.