### PR TITLE
Use published acvm v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,26 +5,44 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b510cf711ccaedb4c56172a52745e9f1cbc2d88731430ceccd2d6eb5b2f6cd"
 dependencies = [
+ "acir_field",
  "flate2",
  "indexmap",
- "noir_field",
  "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir_field"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1224a7cd03cf504dafae9e0b64229ffef1a2211811a406e877c3b7e17517ff"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "blake2",
+ "cfg-if",
+ "hex",
+ "num-bigint",
+ "num-traits",
  "serde",
 ]
 
 [[package]]
 name = "acvm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12081750c69705a0a2677ab0e171c209be69e020ca6c90c8700a40d1de7918a4"
 dependencies = [
  "acir",
+ "acir_field",
  "blake2",
  "hex",
  "indexmap",
  "k256",
- "noir_field",
  "num-bigint",
  "num-traits",
  "sha2",
@@ -1263,21 +1281,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "noir_field"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "blake2",
- "cfg-if",
- "hex",
- "num-bigint",
- "num-traits",
- "serde",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir", rev = "7460dda929130589bccfd6619f9409834b72a135", features = [
-    "bn254",
-] }
+acvm = { version = "0.1.0", features = ["bn254"] }
 
 sled = "0.34.6"
 blake2 = "0.9.1"


### PR DESCRIPTION
This replaces the `acvm` dependency from the noir repo and with the `acvm` from its standalone repo.

This dependency currently can't be downloaded on a fresh install because the `7460dda929130589bccfd6619f9409834b72a135` commit was part of https://github.com/noir-lang/noir/pull/551 but that branch was deleted—so a fresh clone of `noir-lang/noir` doesn't include the commit.

@vezenovm suggested that we point to the https://github.com/noir-lang/acvm repository now that it has been split from the noir repo; however, there has been *a lot* of changes to the project. I've pinned the project to the same commit as the final, shared commit: https://github.com/noir-lang/noir/commit/c15c9dabc7d402b54ea290d2b6e0572f513865bd