### PR TITLE
Update barretenberg_wrapper to use branch

### DIFF
--- a/barretenberg_static_lib/Cargo.lock
+++ b/barretenberg_static_lib/Cargo.lock
@@ -5,26 +5,44 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b510cf711ccaedb4c56172a52745e9f1cbc2d88731430ceccd2d6eb5b2f6cd"
 dependencies = [
+ "acir_field",
  "flate2",
  "indexmap",
- "noir_field",
  "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir_field"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1224a7cd03cf504dafae9e0b64229ffef1a2211811a406e877c3b7e17517ff"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "blake2",
+ "cfg-if",
+ "hex",
+ "num-bigint",
+ "num-traits",
  "serde",
 ]
 
 [[package]]
 name = "acvm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12081750c69705a0a2677ab0e171c209be69e020ca6c90c8700a40d1de7918a4"
 dependencies = [
  "acir",
+ "acir_field",
  "blake2",
  "hex",
  "indexmap",
  "k256",
- "noir_field",
  "num-bigint",
  "num-traits",
  "sha2",
@@ -171,7 +189,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec-connect?rev=47178e9b4d57e9285c5e059dda5cf0a66392c457#47178e9b4d57e9285c5e059dda5cf0a66392c457"
+source = "git+https://github.com/noir-lang/aztec-connect?branch=kw/noir-dsl#2ef8be41993ead9993c09b1d99fef6dc68e231a6"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1096,21 +1114,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "noir_field"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "blake2",
- "cfg-if",
- "hex",
- "num-bigint",
- "num-traits",
- "serde",
 ]
 
 [[package]]

--- a/barretenberg_static_lib/Cargo.toml
+++ b/barretenberg_static_lib/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 common = { path = "../common" }
-barretenberg_wrapper = { git = "https://github.com/noir-lang/aztec-connect", rev = "2c961d511c245d7debef04d99b42c3de4268cad8" }
+barretenberg_wrapper = { git = "https://github.com/noir-lang/aztec-connect", branch = "kw/noir-dsl" }
 
 sha2 = "0.9.3"
 blake2 = "0.9.1"


### PR DESCRIPTION
This updates the `barretenberg_wrapper` crate from noir-lang/aztec-connect to the latest commit. This is necessary to build successfully on Mac with homebrew in a non-default location.

We may want to wait to update this until we land https://github.com/noir-lang/aztec-connect/pull/8 so we have the Clang changes for Linux ARM