### PR TITLE
Fix clippy warnings

### DIFF
--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -1,9 +1,9 @@
 use super::Plonk;
 use crate::composer::{remove_public_inputs, StandardComposer};
-use common::barretenberg_structures::Assignments;
 use common::acvm::acir::{circuit::Circuit, native_types::Witness};
 use common::acvm::FieldElement;
 use common::acvm::{Language, ProofSystemCompiler};
+use common::barretenberg_structures::Assignments;
 use common::serialiser::serialise_circuit;
 use std::collections::BTreeMap;
 
@@ -58,7 +58,7 @@ impl ProofSystemCompiler for Plonk {
     fn get_exact_circuit_size(&self, circuit: Circuit) -> u32 {
         let constraint_system = serialise_circuit(&circuit);
 
-        let mut composer = StandardComposer::new(constraint_system);
+        let composer = StandardComposer::new(constraint_system);
 
         let circuit_size = composer.get_exact_circuit_size();
 

--- a/barretenberg_static_lib/src/acvm_interop/pwg/gadget_call.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/gadget_call.rs
@@ -3,7 +3,6 @@ use blake2::Blake2s;
 use common::acvm::acir::{circuit::gate::GadgetCall, native_types::Witness, OPCODE};
 use common::acvm::pwg::{self, input_to_value};
 use common::acvm::FieldElement;
-use common::merkle::MerkleTree;
 use sha2::Digest;
 use std::collections::BTreeMap;
 

--- a/barretenberg_static_lib/src/acvm_interop/pwg/merkle.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/merkle.rs
@@ -2,8 +2,7 @@
 #![allow(dead_code)]
 use crate::Barretenberg;
 use common::acvm::FieldElement;
-use common::merkle::{MessageHasher, PathHasher};
-use std::path::Path;
+use common::merkle::PathHasher;
 
 impl PathHasher for Barretenberg {
     fn hash(&mut self, left: &FieldElement, right: &FieldElement) -> FieldElement {

--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -140,7 +140,6 @@ impl StandardComposer {
         }
         let now = std::time::Instant::now();
 
-        let no_pub_input: Vec<u8> = Vec::new();
         let verified;
         unsafe {
             verified = barretenberg_wrapper::composer::verify(

--- a/barretenberg_wasm/src/acvm_interop/pwg/merkle.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/merkle.rs
@@ -16,8 +16,8 @@ impl PathHasher for Barretenberg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::merkle::{MerkleTree, MessageHasher, PathHasher};
-    use std::path::Path;
+    use common::merkle::{MerkleTree, MessageHasher};
+
     #[test]
     fn basic_interop_initial_root() {
         use tempfile::tempdir;
@@ -65,14 +65,14 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
-        tree.update_message(0, &vec![0; 64]);
-        tree.update_message(1, &vec![1; 64]);
-        tree.update_message(2, &vec![2; 64]);
-        tree.update_message(3, &vec![3; 64]);
-        tree.update_message(4, &vec![4; 64]);
-        tree.update_message(5, &vec![5; 64]);
-        tree.update_message(6, &vec![6; 64]);
-        let root = tree.update_message(7, &vec![7; 64]);
+        tree.update_message(0, &[0; 64]);
+        tree.update_message(1, &[1; 64]);
+        tree.update_message(2, &[2; 64]);
+        tree.update_message(3, &[3; 64]);
+        tree.update_message(4, &[4; 64]);
+        tree.update_message(5, &[5; 64]);
+        tree.update_message(6, &[6; 64]);
+        let root = tree.update_message(7, &[7; 64]);
 
         assert_eq!(
             "2ef749aee0274b151c91428ace22da4f661a7a6dd0b698a8e2b80e24fabc8432",


### PR DESCRIPTION
This just removes unused imports and uses slices instead of vecs where they're not needed.