### PR TITLE
Remove console_error_panic_hook from barretenberg_static_lib

### DIFF
--- a/barretenberg_static_lib/Cargo.toml
+++ b/barretenberg_static_lib/Cargo.toml
@@ -17,7 +17,6 @@ sled = "0.34.6"
 dirs = "3.0"
 downloader = { version = "0.2.6" }
 tempfile = "3.3.0"
-console_error_panic_hook = { version = "*" }
 indicatif = "0.15.0"
 regex = "1.4.0"
 


### PR DESCRIPTION
This dependency seems to be leftover from before the `aztec_backend_wasm` was split out into its own package. Should be good to remove from here.