### PR TITLE
Remove timing printlns

### DIFF
--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -109,11 +109,6 @@ impl StandardComposer {
         unsafe {
             result = Vec::from_raw_parts(proof_addr, proof_size as usize, proof_size as usize)
         }
-        println!(
-            "Total Proving time (Rust + Static Lib) : {}ns ~ {}seconds",
-            now.elapsed().as_nanos(),
-            now.elapsed().as_secs(),
-        );
         remove_public_inputs(self.constraint_system.public_inputs.len(), result)
     }
 
@@ -140,21 +135,14 @@ impl StandardComposer {
         }
         let now = std::time::Instant::now();
 
-        let verified;
         unsafe {
-            verified = barretenberg_wrapper::composer::verify(
+            barretenberg_wrapper::composer::verify(
                 self.pippenger.pointer(),
                 &proof,
                 &self.constraint_system.to_bytes(),
                 &self.crs.g2_data,
-            );
+            )
         }
-        println!(
-            "Total Verifier time (Rust + Static Lib) : {}ns ~ {}seconds",
-            now.elapsed().as_nanos(),
-            now.elapsed().as_secs(),
-        );
-        verified
     }
 }
 

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -159,11 +159,6 @@ impl StandardComposer {
             proof_ptr as usize,
             proof_ptr as usize + proof_size.unwrap_i32() as usize,
         );
-        println!(
-            "Total Proving time (Rust + WASM) : {}ns ~ {}seconds",
-            now.elapsed().as_nanos(),
-            now.elapsed().as_secs(),
-        );
         remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
     }
 
@@ -215,12 +210,6 @@ impl StandardComposer {
         // self.barretenberg.free(cs_ptr);
         self.barretenberg.free(proof_ptr);
         // self.barretenberg.free(g2_ptr);
-
-        println!(
-            "Total Verifier time (Rust + WASM) : {}ns ~ {}seconds",
-            now.elapsed().as_nanos(),
-            now.elapsed().as_secs(),
-        );
 
         match verified.unwrap_i32() {
             0 => false,


### PR DESCRIPTION
This removes the printouts in the form `Total Proving time (Rust + Static Lib) : 40469750ns ~ 0seconds` which are largely unnecessary and notably clog the output when using the new `nargo test` command.

Users interested in proving and verification time can test it themselves via `time`, `hyperfine`, or other more featureful command line utilities.