### PR TITLE
chore(acvm): Update aztec_backend to reflect acvm 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad7977c11d19ae0dd983b50dc5fd9eb96c002072f75643e45daa6dc0c23fba5"
+checksum = "5d756bcab90b3a4a84dc53245890cf9bb8fcde31a1394931f5abca551b48eb20"
 dependencies = [
  "acir_field",
  "flate2",
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687506e635efa7ce15d6b93ceae14dec1519ed2e54c24298fc8c40e86edbce24"
+checksum = "deb7e1e30625a9125a0e700c6c6fd7442ffbcb1d235933100b791ba3786ef49e"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -32,12 +32,11 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99007127e84602134226eefc2245c59b7fe55853bfeba572714b04c5b3fefdea"
+checksum = "6c4fae94e7f3fe0d21bec4796de00bbf0cd8f781271b5203dea54897aa5387b9"
 dependencies = [
  "acir",
- "acir_field",
  "acvm_stdlib",
  "blake2",
  "hex",
@@ -51,12 +50,11 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f5ef183f4a10b4a257d25c3a37fd090b9e8fbb7dff0902329fb6606b524114"
+checksum = "eaf6617b72c2cd4e965d425bc768bb77a803e485a7e37cbc09cccc5967becd7a"
 dependencies = [
  "acir",
- "acir_field",
 ]
 
 [[package]]

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -77,8 +77,8 @@ impl ProofSystemCompiler for Plonk {
         }
     }
 
-    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) { 
-        todo!() 
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) {
+        todo!()
     }
 
     fn prove_with_pk(

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -77,10 +77,12 @@ impl ProofSystemCompiler for Plonk {
         }
     }
 
+    #[allow(unused_variables)]
     fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) {
         todo!()
     }
 
+    #[allow(unused_variables)]
     fn prove_with_pk(
         &self,
         circuit: Circuit,
@@ -90,6 +92,7 @@ impl ProofSystemCompiler for Plonk {
         todo!()
     }
 
+    #[allow(unused_variables)]
     fn verify_with_vk(
         &self,
         proof: &[u8],

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -60,7 +60,7 @@ impl ProofSystemCompiler for Plonk {
         composer.get_exact_circuit_size()
     }
 
-    fn blackbox_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
+    fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
         match opcode {
             common::acvm::acir::BlackBoxFunc::AES => false,
             common::acvm::acir::BlackBoxFunc::AND => true,
@@ -75,5 +75,28 @@ impl ProofSystemCompiler for Plonk {
             common::acvm::acir::BlackBoxFunc::EcdsaSecp256k1 => true,
             common::acvm::acir::BlackBoxFunc::FixedBaseScalarMul => true,
         }
+    }
+
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) { 
+        todo!() 
+    }
+
+    fn prove_with_pk(
+        &self,
+        circuit: Circuit,
+        witness_values: BTreeMap<Witness, FieldElement>,
+        proving_key: Vec<u8>,
+    ) -> Vec<u8> {
+        todo!()
+    }
+
+    fn verify_with_vk(
+        &self,
+        proof: &[u8],
+        public_inputs: Vec<FieldElement>,
+        circuit: Circuit,
+        verification_key: Vec<u8>,
+    ) -> bool {
+        todo!()
     }
 }

--- a/barretenberg_static_lib/src/acvm_interop/pwg.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg.rs
@@ -10,7 +10,7 @@ use self::gadget_call::GadgetCaller;
 use super::Plonk;
 
 impl PartialWitnessGenerator for Plonk {
-    fn solve_blackbox_function_call(
+    fn solve_black_box_function_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
     ) -> Result<(), common::acvm::OpcodeResolutionError> {

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -78,8 +78,8 @@ impl ProofSystemCompiler for Plonk {
     }
 
     #[allow(unused_variables)]
-    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) { 
-        todo!() 
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) {
+        todo!()
     }
 
     #[allow(unused_variables)]

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -77,8 +77,8 @@ impl ProofSystemCompiler for Plonk {
         }
     }
 
-    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) { 
-        todo!() 
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) {
+        todo!()
     }
 
     fn prove_with_pk(

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -77,10 +77,12 @@ impl ProofSystemCompiler for Plonk {
         }
     }
 
-    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) {
-        todo!()
+    #[allow(unused_variables)]
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) { 
+        todo!() 
     }
 
+    #[allow(unused_variables)]
     fn prove_with_pk(
         &self,
         circuit: Circuit,
@@ -90,6 +92,7 @@ impl ProofSystemCompiler for Plonk {
         todo!()
     }
 
+    #[allow(unused_variables)]
     fn verify_with_vk(
         &self,
         proof: &[u8],

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -60,7 +60,7 @@ impl ProofSystemCompiler for Plonk {
         composer.get_exact_circuit_size()
     }
 
-    fn blackbox_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
+    fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
         match opcode {
             common::acvm::acir::BlackBoxFunc::AES => false,
             common::acvm::acir::BlackBoxFunc::AND => true,
@@ -75,5 +75,28 @@ impl ProofSystemCompiler for Plonk {
             common::acvm::acir::BlackBoxFunc::EcdsaSecp256k1 => true,
             common::acvm::acir::BlackBoxFunc::FixedBaseScalarMul => true,
         }
+    }
+
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) { 
+        todo!() 
+    }
+
+    fn prove_with_pk(
+        &self,
+        circuit: Circuit,
+        witness_values: BTreeMap<Witness, FieldElement>,
+        proving_key: Vec<u8>,
+    ) -> Vec<u8> {
+        todo!()
+    }
+
+    fn verify_with_vk(
+        &self,
+        proof: &[u8],
+        public_inputs: Vec<FieldElement>,
+        circuit: Circuit,
+        verification_key: Vec<u8>,
+    ) -> bool {
+        todo!()
     }
 }

--- a/barretenberg_wasm/src/acvm_interop/pwg.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg.rs
@@ -10,7 +10,7 @@ use self::gadget_call::GadgetCaller;
 use super::Plonk;
 
 impl PartialWitnessGenerator for Plonk {
-    fn solve_blackbox_function_call(
+    fn solve_black_box_function_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
     ) -> Result<(), common::acvm::OpcodeResolutionError> {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { version = "0.3.1", features = ["bn254"] }
+acvm = { version = "0.4.1", features = ["bn254"] }
 
 sled = "0.34.6"
 blake2 = "0.9.1"


### PR DESCRIPTION
Update aztec_backend to reflect the new acvm `0.4.1` release. This will let us update the commit in this PR under the main Noir repo (https://github.com/noir-lang/noir/pull/630) enabling print line statements. 

I use the `#[allow(unused_variables)]` for the unused acvm interface functions. These functions are still a work in progress, but it would be good to update the aztec backend to get the log statements PR in on the main Noir repo.