### PR TITLE
fix: rename gates to opcodes

### DIFF
--- a/aztec_backend_wasm/src/lib.rs
+++ b/aztec_backend_wasm/src/lib.rs
@@ -40,7 +40,7 @@ pub fn compute_witnesses(
     // which are possible
 
     let plonk = Plonk;
-    match plonk.solve(&mut witness_map, circuit.gates) {
+    match plonk.solve(&mut witness_map, circuit.opcodes) {
         Ok(_) => {}
         Err(opcode) => panic!("solver came across an error with opcode {}", opcode),
     };


### PR DESCRIPTION
We're referring to the old "gates" field on `Circuit` rather than the new "opcodes" field. This should be picked up be type checking so we should also investigate why this doesn't error.