### PR TITLE
feat!: update to acvm v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.4.1"
-source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104242ac56c936464e3ac9618e1f635151e83334d8d4138f9a39490ca11acaa9"
 dependencies = [
  "acir_field",
  "flate2",
@@ -15,8 +16,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.4.1"
-source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd6cc7ebc948cde55bf10a8c4f3e1479e03f34e00ee8ab83e86891b693dd503"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -31,8 +33,9 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.4.1"
-source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6145438d6c89c208cae93e49b925b0e2ac1963048a8ee4e002ca0f0de87d789e"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -47,8 +50,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.4.1"
-source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaabcf52a534df7ed591451cf5ac2a765416fee4e38e0c523cc29da8c244aa7c"
 dependencies = [
  "acir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d756bcab90b3a4a84dc53245890cf9bb8fcde31a1394931f5abca551b48eb20"
+source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,11 +16,11 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb7e1e30625a9125a0e700c6c6fd7442ffbcb1d235933100b791ba3786ef49e"
+source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
 dependencies = [
  "ark-bn254",
  "ark-ff",
+ "ark-serialize",
  "blake2",
  "cfg-if",
  "hex",
@@ -33,13 +32,11 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fae94e7f3fe0d21bec4796de00bbf0cd8f781271b5203dea54897aa5387b9"
+source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
 dependencies = [
  "acir",
  "acvm_stdlib",
  "blake2",
- "hex",
  "indexmap",
  "k256",
  "num-bigint",
@@ -51,8 +48,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf6617b72c2cd4e965d425bc768bb77a803e485a7e37cbc09cccc5967becd7a"
+source = "git+https://github.com/noir-lang/acvm?rev=f57ba57c2bb2597edf2b02fb1321c69cf11993ee#f57ba57c2bb2597edf2b02fb1321c69cf11993ee"
 dependencies = [
  "acir",
 ]
@@ -84,6 +80,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -105,29 +112,34 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
+checksum = "3c60370a92f8e1a5f053cad73a862e1b99bc642333cd676fa11c0c39f80f4ac2"
 dependencies = [
  "ark-ff",
+ "ark-poly",
  "ark-serialize",
  "ark-std",
  "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+checksum = "4c2d42532524bee1da5a4f6f733eb4907301baa480829557adcff5dfaeee1d9a"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
  "derivative",
+ "digest 0.10.6",
+ "itertools",
  "num-bigint",
  "num-traits",
  "paste",
@@ -137,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+checksum = "9d6873aaba7959593d89babed381d33e2329453368f1bf3c67e07686a1c1056f"
 dependencies = [
  "quote",
  "syn",
@@ -147,31 +159,58 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+checksum = "f3c2e7d0f2d67cc7fc925355c74d36e7eda19073639be4a0a233d4611b8c959d"
 dependencies = [
  "num-bigint",
  "num-traits",
+ "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "ark-serialize"
-version = "0.3.0"
+name = "ark-poly"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+checksum = "8f6ec811462cabe265cfe1b102fcfe3df79d7d2929c2425673648ee9abfd0272"
 dependencies = [
+ "ark-ff",
+ "ark-serialize",
  "ark-std",
- "digest",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e735959bc173ea4baf13327b19c22d452b8e9e8e8f7b7fc34e6bf0e316c33e"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.6",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd34f0920d995d2c932f38861c416f70de89a6de9875876b012557079603e6cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand",
@@ -304,7 +343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -587,6 +626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
 dependencies = [
  "bitvec",
- "digest",
+ "digest 0.9.0",
  "ff",
  "funty",
  "generic-array",
@@ -1051,7 +1109,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1060,7 +1118,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1094,7 +1161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.1",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1227,6 +1294,15 @@ name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1556,16 +1632,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "pest"
-version = "2.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1913,9 +1979,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -1977,21 +2043,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
@@ -2054,7 +2108,7 @@ dependencies = [
  "block-buffer",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2070,7 +2124,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
 ]
 
@@ -2324,12 +2378,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -60,7 +60,6 @@ impl ProofSystemCompiler for Plonk {
 
     fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
         match opcode {
-            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
             common::acvm::acir::BlackBoxFunc::AES => false,
             common::acvm::acir::BlackBoxFunc::AND => true,
             common::acvm::acir::BlackBoxFunc::XOR => true,
@@ -73,6 +72,7 @@ impl ProofSystemCompiler for Plonk {
             common::acvm::acir::BlackBoxFunc::HashToField128Security => true,
             common::acvm::acir::BlackBoxFunc::EcdsaSecp256k1 => true,
             common::acvm::acir::BlackBoxFunc::FixedBaseScalarMul => true,
+            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
         }
     }
 

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -52,14 +52,15 @@ impl ProofSystemCompiler for Plonk {
         Language::PLONKCSat { width: 3 }
     }
 
-    fn get_exact_circuit_size(&self, circuit: Circuit) -> u32 {
-        let constraint_system = serialise_circuit(&circuit);
+    fn get_exact_circuit_size(&self, circuit: &Circuit) -> u32 {
+        let constraint_system = serialise_circuit(circuit);
 
         StandardComposer::get_exact_circuit_size(&constraint_system)
     }
 
     fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
         match opcode {
+            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
             common::acvm::acir::BlackBoxFunc::AES => false,
             common::acvm::acir::BlackBoxFunc::AND => true,
             common::acvm::acir::BlackBoxFunc::XOR => true,
@@ -75,8 +76,8 @@ impl ProofSystemCompiler for Plonk {
         }
     }
 
-    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>) {
-        let constraint_system = serialise_circuit(&circuit);
+    fn preprocess(&self, circuit: &Circuit) -> (Vec<u8>, Vec<u8>) {
+        let constraint_system = serialise_circuit(circuit);
         let composer = StandardComposer::new(constraint_system);
 
         let proving_key = composer.compute_proving_key();
@@ -87,45 +88,47 @@ impl ProofSystemCompiler for Plonk {
 
     fn prove_with_pk(
         &self,
-        circuit: Circuit,
+        circuit: &Circuit,
         witness_values: BTreeMap<Witness, FieldElement>,
-        proving_key: Vec<u8>,
+        proving_key: &[u8],
     ) -> Vec<u8> {
-        let constraint_system = serialise_circuit(&circuit);
+        let constraint_system = serialise_circuit(circuit);
         let mut composer = StandardComposer::new(constraint_system);
 
         // Add witnesses in the correct order
         // Note: The witnesses are sorted via their witness index
         // witness_values may not have all the witness indexes, e.g for unused witness which are not solved by the solver
-        let mut sorted_witness = Assignments::new();
         let num_witnesses = circuit.num_vars();
-        for i in 1..num_witnesses {
-            // Get the value if it exists. If i does not, then we fill it with the zero value
-            let value = match witness_values.get(&Witness(i)) {
-                Some(value) => *value,
-                None => FieldElement::zero(),
-            };
+        let flattened_witnesses = (1..num_witnesses)
+            .map(|wit_index| {
+                // Get the value if it exists, if not then default to zero value.
+                witness_values
+                    .get(&Witness(wit_index))
+                    .map_or(FieldElement::zero(), |field| *field)
+            })
+            .collect();
 
-            sorted_witness.push(value);
-        }
-
-        composer.create_proof_with_pk(sorted_witness, &proving_key)
+        composer.create_proof_with_pk(Assignments::from_vec(flattened_witnesses), proving_key)
     }
 
     fn verify_with_vk(
         &self,
         proof: &[u8],
-        public_inputs: Vec<FieldElement>,
-        circuit: Circuit,
-        verification_key: Vec<u8>,
+        public_inputs: BTreeMap<Witness, FieldElement>,
+        circuit: &Circuit,
+        verification_key: &[u8],
     ) -> bool {
-        let constraint_system = serialise_circuit(&circuit);
+        let constraint_system = serialise_circuit(circuit);
         let mut composer = StandardComposer::new(constraint_system);
+
+        // Unlike when proving, we omit any unassigned witnesses.
+        // Witness values should be ordered by their index but we skip over any indices without an assignment.
+        let flattened_public_inputs = public_inputs.into_values().collect();
 
         composer.verify_with_vk(
             proof,
-            Some(Assignments::from_vec(public_inputs)),
-            &verification_key,
+            Some(Assignments::from_vec(flattened_public_inputs)),
+            verification_key,
         )
     }
 }

--- a/barretenberg_static_lib/src/acvm_interop/smart_contract.rs
+++ b/barretenberg_static_lib/src/acvm_interop/smart_contract.rs
@@ -6,6 +6,10 @@ use common::serialiser::serialise_circuit;
 use super::Plonk;
 
 impl SmartContract for Plonk {
+    fn eth_contract_from_vk(&self, _verification_key: &[u8]) -> String {
+        todo!("use `eth_contract_from_cs` for now");
+    }
+
     fn eth_contract_from_cs(&self, circuit: Circuit) -> String {
         let constraint_system = serialise_circuit(&circuit);
 

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -63,7 +63,6 @@ impl ProofSystemCompiler for Plonk {
 
     fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
         match opcode {
-            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
             common::acvm::acir::BlackBoxFunc::AES => false,
             common::acvm::acir::BlackBoxFunc::AND => true,
             common::acvm::acir::BlackBoxFunc::XOR => true,
@@ -76,6 +75,7 @@ impl ProofSystemCompiler for Plonk {
             common::acvm::acir::BlackBoxFunc::HashToField128Security => true,
             common::acvm::acir::BlackBoxFunc::EcdsaSecp256k1 => true,
             common::acvm::acir::BlackBoxFunc::FixedBaseScalarMul => true,
+            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
         }
     }
 

--- a/barretenberg_wasm/src/acvm_interop/smart_contract.rs
+++ b/barretenberg_wasm/src/acvm_interop/smart_contract.rs
@@ -7,6 +7,10 @@ use common::serialiser::serialise_circuit;
 use super::Plonk;
 
 impl SmartContract for Plonk {
+    fn eth_contract_from_vk(&self, _verification_key: &[u8]) -> String {
+        todo!("use `eth_contract_from_cs` for now");
+    }
+
     fn eth_contract_from_cs(&self, circuit: Circuit) -> String {
         let constraint_system = serialise_circuit(&circuit);
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git="https://github.com/noir-lang/acvm", rev = "f57ba57c2bb2597edf2b02fb1321c69cf11993ee", features = ["bn254"] }
+acvm = { version = "0.5.0", features = ["bn254"] }
 
 sled = "0.34.6"
 blake2 = "0.9.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { version = "0.4.1", features = ["bn254"] }
+acvm = { git="https://github.com/noir-lang/acvm", rev = "f57ba57c2bb2597edf2b02fb1321c69cf11993ee", features = ["bn254"] }
 
 sled = "0.34.6"
 blake2 = "0.9.1"

--- a/common/src/gadget_caller.rs
+++ b/common/src/gadget_caller.rs
@@ -34,7 +34,7 @@ pub fn solve_blackbox_func_call<B: BarretenbergShared>(
         BlackBoxFunc::EcdsaSecp256k1 => {
             pwg::signature::ecdsa::secp256k1_prehashed(initial_witness, gadget_call)?
         }
-        BlackBoxFunc::AES => {
+        BlackBoxFunc::AES | BlackBoxFunc::Keccak256 => {
             return Err(OpcodeResolutionError::UnsupportedBlackBoxFunc(
                 gadget_call.name,
             ))

--- a/common/src/serialiser.rs
+++ b/common/src/serialiser.rs
@@ -230,7 +230,6 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         schnorr_constraints.push(constraint);
                     }
-                    BlackBoxFunc::AES => panic!("AES has not yet been implemented"),
                     BlackBoxFunc::Pedersen => {
                         let mut inputs = Vec::new();
                         for scalar in gadget_call.inputs.iter() {
@@ -335,6 +334,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         fixed_base_scalar_mul_constraints.push(fixed_base_scalar_mul);
                     }
+                    BlackBoxFunc::Keccak256 => panic!("Keccak256 has not yet been implemented"),
+                    BlackBoxFunc::AES => panic!("AES has not yet been implemented"),
                 };
             }
             Opcode::Directive(_) => {


### PR DESCRIPTION
Updates to use the new ACVM 0.5.0 interface (references for circuits + keys, maps for public inputs when verifying).

Support for `eth_contract_from_vk` and new keccak opcode are left as `todo!()`