### PR TITLE
fix(aztec_backend_wasm): Sort the witness_map after solving

### DIFF
--- a/aztec_backend_wasm/src/lib.rs
+++ b/aztec_backend_wasm/src/lib.rs
@@ -45,15 +45,22 @@ pub fn compute_witnesses(
         Err(opcode) => panic!("solver came across an error with opcode {}", opcode),
     };
 
-    // Serialise the witness in a way that the C++ codebase can deserialise
-    let assignments = crate::barretenberg_structures::Assignments::from_vec(
-        witness_map
-            .into_iter()
-            .map(|(_, field_val)| field_val)
-            .collect(),
-    );
+    // Add witnesses in the correct order
+    // Note: The witnesses are sorted via their witness index
+    // witness_values may not have all the witness indexes, e.g for unused witness which are not solved by the solver
+    let mut sorted_witness = common::barretenberg_structures::Assignments::new();
+    let num_witnesses = circuit.num_vars();
+    for i in 1..num_witnesses {
+        // Get the value if it exists. If i does not, then we fill it with the zero value
+        let value = match witness_map.get(&Witness(i)) {
+            Some(value) => *value,
+            None => FieldElement::zero(),
+        };
 
-    assignments.to_bytes()
+        sorted_witness.push(value);
+    }
+
+    sorted_witness.to_bytes()
 }
 
 #[wasm_bindgen]

--- a/aztec_backend_wasm/src/lib.rs
+++ b/aztec_backend_wasm/src/lib.rs
@@ -47,7 +47,7 @@ pub fn compute_witnesses(
 
     // Add witnesses in the correct order
     // Note: The witnesses are sorted via their witness index
-    // witness_values may not have all the witness indexes, e.g for unused witness which are not solved by the solver
+    // witness_map may not have all the witness indexes, e.g for unused witness which are not solved by the solver
     let mut sorted_witness = common::barretenberg_structures::Assignments::new();
     let num_witnesses = circuit.num_vars();
     for i in 1..num_witnesses {


### PR DESCRIPTION
In the TS packages, there were reported issues of basic programs returning `false` on proof verification. 
For example:
```
fn main(x: u64, y: u64) {
  constrain x < y;
}
``` 
was failing verification. However, this circuit would pass partial witness generation. This told us the witness mapping was correct, but rather the witness array being passed to barretenberg in the TS packages differed from the one being passed in nargo. 

The witness array we compute in `aztec_backend_wasm` is missing the step of adding witnesses in the correct order. Some circuits would still verify correctly such as:
```
fn main(x: u64, y: u64) {
  constrain x != y;
}
``` 
But this would only be because the circuit's witnesses were consecutive, so any missing values in the witness map came at the end and were `0` anyway. 

I added code to check whether the solved witness map has all the witness values, if it does not we fill the value with a zero. This led to the first snippet above verifying true in typescript. 

There were other test cases with merkle_membership that were passing partial witness generation but failing verification. With this addition they are all now passing verification.
