### PR TITLE
feat(ci): add concurrency group for rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,11 @@ name: Rust
 
 on: [push, pull_request]
 
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_n_test:
     name: cargo check & test


### PR DESCRIPTION
This pulls across the change from https://github.com/noir-lang/noir/pull/806 so we can use it in this repo as well.