### PR TITLE
chore: apply non-breaking spellcheck fixes

### DIFF
--- a/aztec_backend_wasm/src/lib.rs
+++ b/aztec_backend_wasm/src/lib.rs
@@ -45,7 +45,7 @@ pub fn compute_witnesses(
         Err(opcode) => panic!("solver came across an error with opcode {}", opcode),
     };
 
-    // Serialise the witness in a way that the C++ codebase can deserialise
+    // Serialize the witness in a way that the C++ codebase can deserialize
     let assignments = crate::barretenberg_structures::Assignments::from_vec(
         witness_map
             .into_iter()

--- a/barretenberg_js/src/acvm_interop/proof_system.rs
+++ b/barretenberg_js/src/acvm_interop/proof_system.rs
@@ -22,7 +22,7 @@ impl ProofSystemCompiler for Plonk {
         circuit: Circuit,
         witness_values: BTreeMap<Witness, FieldElement>,
     ) -> Vec<u8> {
-        //Serialise to disk
+        //Serialize to disk
         let serialized = circuit.to_bytes();
         let mut circuit_file = NamedTempFile::new().unwrap();
         circuit_file.write_all(serialized.as_slice());

--- a/barretenberg_static_lib/src/acvm_interop/pwg.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg.rs
@@ -14,6 +14,6 @@ impl PartialWitnessGenerator for Plonk {
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
     ) -> Result<(), common::acvm::OpcodeResolutionError> {
-        GadgetCaller::solve_blackbox_func_call(initial_witness, func_call)
+        GadgetCaller::solve_black_box_func_call(initial_witness, func_call)
     }
 }

--- a/barretenberg_static_lib/src/acvm_interop/pwg/gadget_call.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/gadget_call.rs
@@ -34,11 +34,11 @@ impl BarretenbergShared for Barretenberg {
 }
 
 impl GadgetCaller {
-    pub fn solve_blackbox_func_call(
+    pub fn solve_black_box_func_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gadget_call: &BlackBoxFuncCall,
     ) -> Result<(), OpcodeResolutionError> {
-        common::gadget_caller::solve_blackbox_func_call::<Barretenberg>(
+        common::gadget_caller::solve_black_box_func_call::<Barretenberg>(
             initial_witness,
             gadget_call,
         )

--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -494,20 +494,20 @@ mod test {
         for i in 13..(13 + 64) {
             signature_indices[i - 13] = i as i32;
         }
-        let result_indice = signature_indices.last().unwrap() + 1;
+        let result_index = signature_indices.last().unwrap() + 1;
 
         let constraint = SchnorrConstraint {
             message: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             public_key_x: 11,
             public_key_y: 12,
             signature: signature_indices,
-            result: result_indice,
+            result: result_index,
         };
 
         let arith_constraint = Constraint {
-            a: result_indice,
-            b: result_indice,
-            c: result_indice,
+            a: result_index,
+            b: result_index,
+            c: result_index,
             qm: Scalar::zero(),
             ql: Scalar::zero(),
             qr: Scalar::zero(),

--- a/barretenberg_static_lib/src/integration.rs
+++ b/barretenberg_static_lib/src/integration.rs
@@ -52,7 +52,7 @@ fn integration_test_does_not_panic() {
 
     println!("Constraint system created\n");
 
-    println!("Initialising CRS, FFT, Pippenger and compiling WASM\n");
+    println!("Initializing CRS, FFT, Pippenger and compiling WASM\n");
     let mut composer = StandardComposer::new(constraint_system.size());
     println!("WASM compiled and the standard composer is ready\n");
 

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -42,7 +42,7 @@ impl ProofSystemCompiler for Plonk {
         public_inputs: Vec<FieldElement>,
         circuit: Circuit,
     ) -> bool {
-        let constraint_system = common::serialiser::serialise_circuit(&circuit);
+        let constraint_system = serialise_circuit(&circuit);
 
         let mut composer = StandardComposer::new(constraint_system);
 

--- a/barretenberg_wasm/src/acvm_interop/pwg.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg.rs
@@ -14,6 +14,6 @@ impl PartialWitnessGenerator for Plonk {
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
     ) -> Result<(), common::acvm::OpcodeResolutionError> {
-        GadgetCaller::solve_blackbox_func_call(initial_witness, func_call)
+        GadgetCaller::solve_black_box_func_call(initial_witness, func_call)
     }
 }

--- a/barretenberg_wasm/src/acvm_interop/pwg/gadget_call.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/gadget_call.rs
@@ -34,11 +34,11 @@ impl BarretenbergShared for Barretenberg {
 }
 
 impl GadgetCaller {
-    pub fn solve_blackbox_func_call(
+    pub fn solve_black_box_func_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gadget_call: &BlackBoxFuncCall,
     ) -> Result<(), OpcodeResolutionError> {
-        common::gadget_caller::solve_blackbox_func_call::<Barretenberg>(
+        common::gadget_caller::solve_black_box_func_call::<Barretenberg>(
             initial_witness,
             gadget_call,
         )

--- a/barretenberg_wasm/src/acvm_interop/pwg/merkle.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/merkle.rs
@@ -124,7 +124,7 @@ mod tests {
             result : true,
             message : vec![0;64],
             should_update_tree: false,
-            error_msg : "this should always be true, since the tree is initialised with 64 zeroes"
+            error_msg : "this should always be true, since the tree is initialized with 64 zeroes"
         },
         Test {
             index : "0",

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -54,12 +54,12 @@ pub struct Constraint {
 impl Constraint {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
-        // serialise Wires
+        // serialize Wires
         buffer.extend_from_slice(&self.a.to_be_bytes());
         buffer.extend_from_slice(&self.b.to_be_bytes());
         buffer.extend_from_slice(&self.c.to_be_bytes());
 
-        // serialise selectors
+        // serialize selectors
         buffer.extend_from_slice(&self.qm.to_be_bytes());
         buffer.extend_from_slice(&self.ql.to_be_bytes());
         buffer.extend_from_slice(&self.qr.to_be_bytes());
@@ -79,7 +79,7 @@ pub struct RangeConstraint {
 impl RangeConstraint {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
-        // Serialiasing Wires
+        // Serializing Wires
         buffer.extend_from_slice(&self.a.to_be_bytes());
         buffer.extend_from_slice(&self.num_bits.to_be_bytes());
 
@@ -296,7 +296,7 @@ pub struct FixedBaseScalarMulConstraint {
 impl FixedBaseScalarMulConstraint {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
-        // Serialising Wires
+        // Serializing Wires
         buffer.extend_from_slice(&self.scalar.to_be_bytes());
         buffer.extend_from_slice(&self.pubkey_x.to_be_bytes());
         buffer.extend_from_slice(&self.pubkey_y.to_be_bytes());
@@ -336,7 +336,7 @@ impl LogicConstraint {
 
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
-        // Serialising Wires
+        // Serializing Wires
         buffer.extend_from_slice(&self.a.to_be_bytes());
         buffer.extend_from_slice(&self.b.to_be_bytes());
         buffer.extend_from_slice(&self.result.to_be_bytes());
@@ -378,77 +378,77 @@ impl ConstraintSystem {
             buffer.extend_from_slice(&pub_input.to_be_bytes());
         }
 
-        // Serialise each Logic constraint
+        // Serialize each Logic constraint
         let logic_constraints_len = self.logic_constraints.len() as u32;
         buffer.extend_from_slice(&logic_constraints_len.to_be_bytes());
         for constraint in self.logic_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Range constraint
+        // Serialize each Range constraint
         let range_constraints_len = self.range_constraints.len() as u32;
         buffer.extend_from_slice(&range_constraints_len.to_be_bytes());
         for constraint in self.range_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Sha256 constraint
+        // Serialize each Sha256 constraint
         let sha256_constraints_len = self.sha256_constraints.len() as u32;
         buffer.extend_from_slice(&sha256_constraints_len.to_be_bytes());
         for constraint in self.sha256_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Merkle Membership constraint
+        // Serialize each Merkle Membership constraint
         let merkle_membership_constraints_len = self.merkle_membership_constraints.len() as u32;
         buffer.extend_from_slice(&merkle_membership_constraints_len.to_be_bytes());
         for constraint in self.merkle_membership_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Schnorr constraint
+        // Serialize each Schnorr constraint
         let schnorr_len = self.schnorr_constraints.len() as u32;
         buffer.extend_from_slice(&schnorr_len.to_be_bytes());
         for constraint in self.schnorr_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each ECDSA constraint
+        // Serialize each ECDSA constraint
         let ecdsa_len = self.ecdsa_secp256k1_constraints.len() as u32;
         buffer.extend_from_slice(&ecdsa_len.to_be_bytes());
         for constraint in self.ecdsa_secp256k1_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Blake2s constraint
+        // Serialize each Blake2s constraint
         let blake2s_len = self.blake2s_constraints.len() as u32;
         buffer.extend_from_slice(&blake2s_len.to_be_bytes());
         for constraint in self.blake2s_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Pedersen constraint
+        // Serialize each Pedersen constraint
         let pedersen_len = self.pedersen_constraints.len() as u32;
         buffer.extend_from_slice(&pedersen_len.to_be_bytes());
         for constraint in self.pedersen_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each HashToField constraint
+        // Serialize each HashToField constraint
         let h2f_len = self.hash_to_field_constraints.len() as u32;
         buffer.extend_from_slice(&h2f_len.to_be_bytes());
         for constraint in self.hash_to_field_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each HashToField constraint
+        // Serialize each HashToField constraint
         let fixed_base_scalar_mul_len = self.fixed_base_scalar_mul_constraints.len() as u32;
         buffer.extend_from_slice(&fixed_base_scalar_mul_len.to_be_bytes());
         for constraint in self.fixed_base_scalar_mul_constraints.iter() {
             buffer.extend(&constraint.to_bytes());
         }
 
-        // Serialise each Arithmetic constraint
+        // Serialize each Arithmetic constraint
         let constraints_len = self.constraints.len() as u32;
         buffer.extend_from_slice(&constraints_len.to_be_bytes());
         for constraint in self.constraints.iter() {

--- a/common/src/gadget_caller.rs
+++ b/common/src/gadget_caller.rs
@@ -24,7 +24,7 @@ pub trait BarretenbergShared: PathHasher {
     fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement);
 }
 
-pub fn solve_blackbox_func_call<B: BarretenbergShared>(
+pub fn solve_black_box_func_call<B: BarretenbergShared>(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     gadget_call: &BlackBoxFuncCall,
 ) -> Result<(), OpcodeResolutionError> {

--- a/common/src/serialiser.rs
+++ b/common/src/serialiser.rs
@@ -1,5 +1,5 @@
 // Aztec uses a `TurboFormat` object in order to bridge the gap between Rust and C++.
-// This serialiser converts the IR into the `TurboFormat` which can then be fed into the WASM file
+// This serializer converts the IR into the `TurboFormat` which can then be fed into the WASM file
 use crate::barretenberg_structures::{
     Blake2sConstraint, Constraint, ConstraintSystem, EcdsaConstraint, FixedBaseScalarMulConstraint,
     HashToFieldConstraint, LogicConstraint, MerkleMembershipConstraint, PedersenConstraint,
@@ -28,7 +28,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
     for gate in circuit.opcodes.iter() {
         match gate {
             Opcode::Arithmetic(expression) => {
-                let constraint = serialise_arithmetic_gates(expression);
+                let constraint = serialize_arithmetic_gates(expression);
                 constraints.push(constraint);
             }
             Opcode::BlackBoxFuncCall(gadget_call) => {
@@ -363,7 +363,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 }
 
 #[allow(non_snake_case)]
-fn serialise_arithmetic_gates(gate: &Expression) -> Constraint {
+fn serialize_arithmetic_gates(gate: &Expression) -> Constraint {
     let mut a: i32 = 0;
     let mut b: i32 = 0;
     let mut c: i32 = 0;

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
         "subslice",
         "TURBOVERIFIER",
         "vals",
+        "wasi",
         // In Solidity
         //
         "addmod",


### PR DESCRIPTION
This applies all of the non-breaking spell check fixes. We also have other changes to make but they either affect:
1. The verifier smart contract (non-breaking)
2. Breaking spelling changes which affect the interface e.g. `serialise_acir_to_barrtenberg_circuit`