### PR TITLE
chore: simplifications and deduplications of shared code

### DIFF
--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -45,7 +45,7 @@ impl ProofSystemCompiler for Plonk {
 
         let mut composer = StandardComposer::new(constraint_system);
 
-        composer.verify(proof, Some(Assignments::from_vec(public_inputs)))
+        composer.verify(proof, Assignments::from_vec(public_inputs))
     }
 
     fn np_language(&self) -> Language {
@@ -127,7 +127,7 @@ impl ProofSystemCompiler for Plonk {
 
         composer.verify_with_vk(
             proof,
-            Some(Assignments::from_vec(flattened_public_inputs)),
+            Assignments::from_vec(flattened_public_inputs),
             verification_key,
         )
     }

--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -1,6 +1,6 @@
 use super::crs::CRS;
 use super::pippenger::Pippenger;
-use common::barretenberg_structures::*;
+use common::{barretenberg_structures::*, proof};
 use std::slice;
 pub struct StandardComposer {
     pippenger: Pippenger,
@@ -110,7 +110,7 @@ impl StandardComposer {
         unsafe {
             result = Vec::from_raw_parts(proof_addr, proof_size as usize, proof_size as usize)
         }
-        remove_public_inputs(self.constraint_system.public_inputs.len(), result)
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), result)
     }
 
     pub fn verify(
@@ -125,15 +125,7 @@ impl StandardComposer {
         // This is non-standard however, so this Rust wrapper will strip the public inputs
         // from proofs created by Barretenberg. Then in Verify we prepend them again.
 
-        let mut proof = proof.to_vec();
-        if !public_inputs.0.is_empty() {
-            let mut proof_with_pi = Vec::new();
-            for assignment in public_inputs.0.into_iter() {
-                proof_with_pi.extend(assignment.to_be_bytes());
-            }
-            proof_with_pi.extend(proof);
-            proof = proof_with_pi;
-        }
+        let proof = proof::prepend_public_inputs(proof.to_vec(), public_inputs);
 
         unsafe {
             barretenberg_wrapper::composer::verify(
@@ -223,7 +215,7 @@ impl StandardComposer {
         unsafe {
             result = Vec::from_raw_parts(proof_addr, proof_size as usize, proof_size as usize);
         }
-        remove_public_inputs(self.constraint_system.public_inputs.len(), result.to_vec())
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), result.to_vec())
     }
 
     pub fn verify_with_vk(
@@ -263,15 +255,6 @@ impl StandardComposer {
         }
         verified
     }
-}
-
-// TODO: move this to common
-pub(crate) fn remove_public_inputs(num_pub_inputs: usize, proof: Vec<u8>) -> Vec<u8> {
-    // This is only for public inputs and for Barretenberg.
-    // Barretenberg only used bn254, so each element is 32 bytes.
-    // To remove the public inputs, we need to remove (num_pub_inputs * 32) bytes
-    let num_bytes_to_remove = 32 * num_pub_inputs;
-    proof[num_bytes_to_remove..].to_vec()
 }
 
 fn pow2ceil(v: u32) -> u32 {

--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -110,7 +110,7 @@ impl StandardComposer {
         unsafe {
             result = Vec::from_raw_parts(proof_addr, proof_size as usize, proof_size as usize)
         }
-        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), result)
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), &result)
     }
 
     pub fn verify(
@@ -215,7 +215,7 @@ impl StandardComposer {
         unsafe {
             result = Vec::from_raw_parts(proof_addr, proof_size as usize, proof_size as usize);
         }
-        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), result.to_vec())
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), &result)
     }
 
     pub fn verify_with_vk(

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -131,7 +131,7 @@ impl ProofSystemCompiler for Plonk {
 
         composer.verify_with_vk(
             proof,
-            Some(Assignments::from_vec(flattened_public_inputs)),
+            Assignments::from_vec(flattened_public_inputs),
             verification_key,
         )
     }

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -146,7 +146,7 @@ impl StandardComposer {
             proof_ptr as usize,
             proof_ptr as usize + proof_size.unwrap_i32() as usize,
         );
-        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), &proof)
     }
 
     pub fn verify(
@@ -281,7 +281,7 @@ impl StandardComposer {
             proof_ptr as usize,
             proof_ptr as usize + proof_size.unwrap_i32() as usize,
         );
-        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), &proof)
     }
 
     pub fn verify_with_vk(

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -4,6 +4,7 @@ use common::barretenberg_structures::Assignments;
 use common::barretenberg_structures::ConstraintSystem;
 use common::barretenberg_structures::WitnessAssignments;
 use common::crs::CRS;
+use common::proof;
 use wasmer::Value;
 
 pub struct StandardComposer {
@@ -145,7 +146,7 @@ impl StandardComposer {
             proof_ptr as usize,
             proof_ptr as usize + proof_size.unwrap_i32() as usize,
         );
-        remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
     }
 
     pub fn verify(
@@ -280,7 +281,7 @@ impl StandardComposer {
             proof_ptr as usize,
             proof_ptr as usize + proof_size.unwrap_i32() as usize,
         );
-        remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
+        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
     }
 
     pub fn verify_with_vk(
@@ -296,16 +297,7 @@ impl StandardComposer {
         // This is non-standard however, so this Rust wrapper will strip the public inputs
         // from proofs created by Barretenberg. Then in Verify we prepend them again.
         //
-
-        let mut proof = proof.to_vec();
-        if !public_inputs.0.is_empty() {
-            let mut proof_with_pi = Vec::new();
-            for assignment in public_inputs.0.into_iter() {
-                proof_with_pi.extend(assignment.to_be_bytes());
-            }
-            proof_with_pi.extend(proof);
-            proof = proof_with_pi;
-        }
+        let proof = proof::prepend_public_inputs(proof.to_vec(), public_inputs);
 
         let cs_buf = self.constraint_system.to_bytes();
         let cs_ptr = self.barretenberg.allocate(&cs_buf);
@@ -338,14 +330,6 @@ impl StandardComposer {
             _ => panic!("Expected a 1 or a zero for the verification result"),
         }
     }
-}
-
-pub(crate) fn remove_public_inputs(num_pub_inputs: usize, proof: Vec<u8>) -> Vec<u8> {
-    // This is only for public inputs and for Barretenberg.
-    // Barretenberg only used bn254, so each element is 32 bytes.
-    // To remove the public inputs, we need to remove (num_pub_inputs * 32) bytes
-    let num_bytes_to_remove = 32 * num_pub_inputs;
-    proof[num_bytes_to_remove..].to_vec()
 }
 
 fn pow2ceil(v: u32) -> u32 {

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -288,7 +288,7 @@ impl StandardComposer {
         // XXX: Important: This assumes that the proof does not have the public inputs pre-pended to it
         // This is not the case, if you take the proof directly from Barretenberg
         proof: &[u8],
-        public_inputs: Option<Assignments>,
+        public_inputs: Assignments,
         verification_key: &[u8],
     ) -> bool {
         // Prepend the public inputs to the proof.
@@ -298,10 +298,10 @@ impl StandardComposer {
         //
 
         let mut proof = proof.to_vec();
-        if let Some(pi) = &public_inputs {
+        if !public_inputs.0.is_empty() {
             let mut proof_with_pi = Vec::new();
-            for assignment in pi.0.iter() {
-                proof_with_pi.extend(&assignment.to_be_bytes());
+            for assignment in public_inputs.0.into_iter() {
+                proof_with_pi.extend(assignment.to_be_bytes());
             }
             proof_with_pi.extend(proof);
             proof = proof_with_pi;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,5 +7,7 @@ pub mod crs;
 pub mod merkle;
 pub mod serialiser;
 
+pub mod proof;
+
 // Re-export acvm
 pub use acvm;

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::barretenberg_structures::Assignments;
 
-pub fn remove_public_inputs(num_pub_inputs: usize, proof: Vec<u8>) -> Vec<u8> {
+pub fn remove_public_inputs(num_pub_inputs: usize, proof: &[u8]) -> Vec<u8> {
     // This is only for public inputs and for Barretenberg.
     // Barretenberg only used bn254, so each element is 32 bytes.
     // To remove the public inputs, we need to remove (num_pub_inputs * 32) bytes

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -1,0 +1,22 @@
+use crate::barretenberg_structures::Assignments;
+
+pub fn remove_public_inputs(num_pub_inputs: usize, proof: Vec<u8>) -> Vec<u8> {
+    // This is only for public inputs and for Barretenberg.
+    // Barretenberg only used bn254, so each element is 32 bytes.
+    // To remove the public inputs, we need to remove (num_pub_inputs * 32) bytes
+    let num_bytes_to_remove = 32 * num_pub_inputs;
+    proof[num_bytes_to_remove..].to_vec()
+}
+
+pub fn prepend_public_inputs(proof: Vec<u8>, public_inputs: Assignments) -> Vec<u8> {
+    if public_inputs.0.is_empty() {
+        return proof;
+    }
+
+    let public_inputs_bytes = public_inputs
+        .0
+        .into_iter()
+        .flat_map(|assignment| assignment.to_be_bytes());
+
+    public_inputs_bytes.chain(proof.into_iter()).collect()
+}


### PR DESCRIPTION
We never pass `None` as the public inputs, it's always `Some` empty `Assignments` when we have no public inputs, I've then removed this extra layer.

I've also pulled all the code related to prepending and stripping public inputs to/from proofs into `common` so all methods can reuse it.