### PR TITLE
chore: deduplicate logic for prepending public inputs 

### DIFF
--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -231,15 +231,7 @@ impl StandardComposer {
         // This is non-standard however, so this Rust wrapper will strip the public inputs
         // from proofs created by Barretenberg. Then in Verify we prepend them again.
 
-        let mut proof = proof.to_vec();
-        if !public_inputs.0.is_empty() {
-            let mut proof_with_pi = Vec::new();
-            for assignment in public_inputs.0.into_iter() {
-                proof_with_pi.extend(assignment.to_be_bytes());
-            }
-            proof_with_pi.extend(proof);
-            proof = proof_with_pi;
-        }
+        let proof = proof::prepend_public_inputs(proof.to_vec(), public_inputs);
 
         let cs_buf = self.constraint_system.to_bytes();
         let verification_key = verification_key.to_vec();

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -46,7 +46,7 @@ impl ProofSystemCompiler for Plonk {
 
         let mut composer = StandardComposer::new(constraint_system);
 
-        composer.verify(proof, Some(Assignments::from_vec(public_inputs)))
+        composer.verify(proof, Assignments::from_vec(public_inputs))
     }
 
     fn np_language(&self) -> Language {

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -154,7 +154,7 @@ impl StandardComposer {
         // XXX: Important: This assumes that the proof does not have the public inputs pre-pended to it
         // This is not the case, if you take the proof directly from Barretenberg
         proof: &[u8],
-        public_inputs: Option<Assignments>,
+        public_inputs: Assignments,
     ) -> bool {
         // Prepend the public inputs to the proof.
         // This is how Barretenberg expects it to be.
@@ -162,15 +162,7 @@ impl StandardComposer {
         // from proofs created by Barretenberg. Then in Verify we prepend them again.
         //
 
-        let mut proof = proof.to_vec();
-        if let Some(pi) = &public_inputs {
-            let mut proof_with_pi = Vec::new();
-            for assignment in pi.0.iter() {
-                proof_with_pi.extend(&assignment.to_be_bytes());
-            }
-            proof_with_pi.extend(proof);
-            proof = proof_with_pi;
-        }
+        let proof = proof::prepend_public_inputs(proof.to_vec(), public_inputs);
 
         let cs_buf = self.constraint_system.to_bytes();
         let cs_ptr = self.barretenberg.allocate(&cs_buf);


### PR DESCRIPTION
Looks like #66 missed a couple of instances of the logic to prepend the public inputs onto the proof.