### PR TITLE
chore: replace incorrect flag to mark `common` private

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-private = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Looks like I misread the docs when making #73, rather than marking `common` as private we should mark it as non-publishable.