### PR TITLE
chore: bump to ACVM 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104242ac56c936464e3ac9618e1f635151e83334d8d4138f9a39490ca11acaa9"
+checksum = "744c21590f6da95914f1d83f247dba49d4f287beb725bfbcbc54eaf823484b1a"
 dependencies = [
  "acir_field",
  "flate2",
@@ -16,26 +16,23 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd6cc7ebc948cde55bf10a8c4f3e1479e03f34e00ee8ab83e86891b693dd503"
+checksum = "081a09b71facabddd411bfb8459c0f4d9350c39707680da6c04debb3db9de503"
 dependencies = [
  "ark-bn254",
  "ark-ff",
- "ark-serialize",
- "blake2",
  "cfg-if",
  "hex",
  "num-bigint",
- "num-traits",
  "serde",
 ]
 
 [[package]]
 name = "acvm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6145438d6c89c208cae93e49b925b0e2ac1963048a8ee4e002ca0f0de87d789e"
+checksum = "73876b7d5d23d0826ea4c9150b4a62af0b20a6937a79472ee0ceda30868aa207"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -50,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaabcf52a534df7ed591451cf5ac2a765416fee4e38e0c523cc29da8c244aa7c"
+checksum = "b2259c21b06db652e41bddb1deb22da8d303746a0e8bf877983c7d83f71943b8"
 dependencies = [
  "acir",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ private = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { version = "0.5.0", features = ["bn254"] }
+acvm = { version = "0.6.0", features = ["bn254"] }
 
 sled = "0.34.6"
 blake2 = "0.9.1"

--- a/common/src/serializer.rs
+++ b/common/src/serializer.rs
@@ -338,8 +338,8 @@ pub fn serialize_circuit(circuit: &Circuit) -> ConstraintSystem {
                     BlackBoxFunc::AES => panic!("AES has not yet been implemented"),
                 };
             }
-            Opcode::Directive(_) => {
-                // Directives are only needed by the pwg
+            Opcode::Directive(_) | Opcode::Block(_, _) => {
+                // Directives and Blocks are only needed by the pwg
             }
         }
     }

--- a/common/src/serializer.rs
+++ b/common/src/serializer.rs
@@ -338,8 +338,11 @@ pub fn serialize_circuit(circuit: &Circuit) -> ConstraintSystem {
                     BlackBoxFunc::AES => panic!("AES has not yet been implemented"),
                 };
             }
-            Opcode::Directive(_) | Opcode::Block(_, _) => {
-                // Directives and Blocks are only needed by the pwg
+            Opcode::Directive(_) => {
+                // Directives are only needed by the pwg
+            }
+            Opcode::Block(_, _) => {
+                // TODO: implement serialization of blocks to match BB's interface
             }
         }
     }


### PR DESCRIPTION
This PR updates us to use the new version of the ACVM crate. The only change which is relevant is the addition of the `Block` opcode.

@guipublic It seems to me that we can just handle this similarly to directives when serializing for BB. Let me know if we should handle this differently.