### PR TITLE
chore: use qualified name for `std::cell::Cell`

### DIFF
--- a/barretenberg_wasm/src/lib.rs
+++ b/barretenberg_wasm/src/lib.rs
@@ -76,7 +76,7 @@ impl Barretenberg {
         #[cfg(not(feature = "js"))]
         return memory.view()[start..end]
             .iter()
-            .map(|cell: &Cell<u8>| cell.get())
+            .map(|cell: &std::cell::Cell<u8>| cell.get())
             .collect();
     }
 


### PR DESCRIPTION
Addresses https://github.com/noir-lang/aztec_backend/pull/79#discussion_r1129927419