### PR TITLE
chore: Duplicate static_lib tests into wasm to verify same functionality

### DIFF
--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -1,8 +1,6 @@
 use super::pippenger::Pippenger;
 use super::Barretenberg;
-use common::barretenberg_structures::Assignments;
-use common::barretenberg_structures::ConstraintSystem;
-use common::barretenberg_structures::WitnessAssignments;
+use common::barretenberg_structures::*;
 use common::crs::CRS;
 use common::proof;
 use wasmer::Value;
@@ -250,4 +248,389 @@ fn pow2ceil(v: u32) -> u32 {
         p <<= 1;
     }
     p
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use common::barretenberg_structures::{Constraint, PedersenConstraint, Scalar};
+
+    #[test]
+    fn test_a_single_constraint_no_pub_inputs() {
+        let constraint = Constraint {
+            a: 1,
+            b: 2,
+            c: 3,
+            qm: Scalar::zero(),
+            ql: Scalar::one(),
+            qr: Scalar::one(),
+            qo: -Scalar::one(),
+            qc: Scalar::zero(),
+        };
+
+        let constraint_system = ConstraintSystem {
+            var_num: 4,
+            public_inputs: vec![],
+            logic_constraints: vec![],
+            range_constraints: vec![],
+            sha256_constraints: vec![],
+            merkle_membership_constraints: vec![],
+            schnorr_constraints: vec![],
+            blake2s_constraints: vec![],
+            pedersen_constraints: vec![],
+            hash_to_field_constraints: vec![],
+            constraints: vec![constraint],
+            ecdsa_secp256k1_constraints: vec![],
+            fixed_base_scalar_mul_constraints: vec![],
+        };
+
+        let case_1 = WitnessResult {
+            witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
+            public_inputs: Assignments::default(),
+            result: true,
+        };
+        let case_2 = WitnessResult {
+            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::zero()]),
+            public_inputs: Assignments::default(),
+            result: true,
+        };
+        let case_3 = WitnessResult {
+            witness: Assignments(vec![10_i128.into(), (-3_i128).into(), 7_i128.into()]),
+            public_inputs: Assignments::default(),
+            result: true,
+        };
+        let case_4 = WitnessResult {
+            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::one()]),
+            public_inputs: Assignments::default(),
+            result: false,
+        };
+        let case_5 = WitnessResult {
+            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 6_i128.into()]),
+            public_inputs: Assignments::default(),
+            result: false,
+        };
+        let test_cases = vec![case_1, case_2, case_3, case_4, case_5];
+
+        test_composer_with_pk_vk(constraint_system, test_cases);
+    }
+    #[test]
+    fn test_a_single_constraint_with_pub_inputs() {
+        let constraint = Constraint {
+            a: 1,
+            b: 2,
+            c: 3,
+            qm: Scalar::zero(),
+            ql: Scalar::one(),
+            qr: Scalar::one(),
+            qo: -Scalar::one(),
+            qc: Scalar::zero(),
+        };
+
+        let constraint_system = ConstraintSystem {
+            var_num: 4,
+            public_inputs: vec![1, 2],
+            logic_constraints: vec![],
+            range_constraints: vec![],
+            sha256_constraints: vec![],
+            merkle_membership_constraints: vec![],
+            schnorr_constraints: vec![],
+            blake2s_constraints: vec![],
+            pedersen_constraints: vec![],
+            hash_to_field_constraints: vec![],
+            constraints: vec![constraint],
+            ecdsa_secp256k1_constraints: vec![],
+            fixed_base_scalar_mul_constraints: vec![],
+        };
+
+        // This fails because the constraint system requires public inputs,
+        // but none are supplied in public_inputs. So the verifier will not
+        // supply anything.
+        let case_1 = WitnessResult {
+            witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
+            public_inputs: Assignments::default(),
+            result: false,
+        };
+        let case_2 = WitnessResult {
+            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::zero()]),
+            public_inputs: Assignments(vec![Scalar::zero(), Scalar::zero()]),
+            result: true,
+        };
+
+        let case_3 = WitnessResult {
+            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 6_i128.into()]),
+            public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
+            result: false,
+        };
+
+        // Not enough public inputs
+        let case_4 = WitnessResult {
+            witness: Assignments(vec![
+                Scalar::one(),
+                Scalar::from(2_i128),
+                Scalar::from(6_i128),
+            ]),
+            public_inputs: Assignments(vec![Scalar::one()]),
+            result: false,
+        };
+
+        let case_5 = WitnessResult {
+            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 3_i128.into()]),
+            public_inputs: Assignments(vec![Scalar::one(), 2_i128.into()]),
+            result: true,
+        };
+
+        let case_6 = WitnessResult {
+            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 3_i128.into()]),
+            public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
+            result: false,
+        };
+        let test_cases = vec![
+            /*case_1,*/ case_2, case_3, /*case_4,*/ case_5, case_6,
+        ];
+
+        test_composer_with_pk_vk(constraint_system, test_cases);
+    }
+
+    #[test]
+    fn test_multiple_constraints() {
+        let constraint = Constraint {
+            a: 1,
+            b: 2,
+            c: 3,
+            qm: Scalar::zero(),
+            ql: Scalar::one(),
+            qr: Scalar::one(),
+            qo: -Scalar::one(),
+            qc: Scalar::zero(),
+        };
+        let constraint2 = Constraint {
+            a: 2,
+            b: 3,
+            c: 4,
+            qm: Scalar::one(),
+            ql: Scalar::zero(),
+            qr: Scalar::zero(),
+            qo: -Scalar::one(),
+            qc: Scalar::one(),
+        };
+
+        let constraint_system = ConstraintSystem {
+            var_num: 5,
+            public_inputs: vec![1],
+            logic_constraints: vec![],
+            range_constraints: vec![],
+            sha256_constraints: vec![],
+            merkle_membership_constraints: vec![],
+            schnorr_constraints: vec![],
+            blake2s_constraints: vec![],
+            pedersen_constraints: vec![],
+            hash_to_field_constraints: vec![],
+            constraints: vec![constraint, constraint2],
+            ecdsa_secp256k1_constraints: vec![],
+            fixed_base_scalar_mul_constraints: vec![],
+        };
+
+        let case_1 = WitnessResult {
+            witness: Assignments(vec![
+                1_i128.into(),
+                1_i128.into(),
+                2_i128.into(),
+                3_i128.into(),
+            ]),
+            public_inputs: Assignments(vec![Scalar::one()]),
+            result: true,
+        };
+        let case_2 = WitnessResult {
+            witness: Assignments(vec![
+                1_i128.into(),
+                1_i128.into(),
+                2_i128.into(),
+                13_i128.into(),
+            ]),
+            public_inputs: Assignments(vec![Scalar::one()]),
+            result: false,
+        };
+
+        test_composer_with_pk_vk(constraint_system, vec![case_1, case_2]);
+    }
+
+    #[test]
+    fn test_schnorr_constraints() {
+        let mut signature_indices = [0i32; 64];
+        for i in 13..(13 + 64) {
+            signature_indices[i - 13] = i as i32;
+        }
+        let result_index = signature_indices.last().unwrap() + 1;
+
+        let constraint = SchnorrConstraint {
+            message: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            public_key_x: 11,
+            public_key_y: 12,
+            signature: signature_indices,
+            result: result_index,
+        };
+
+        let arith_constraint = Constraint {
+            a: result_index,
+            b: result_index,
+            c: result_index,
+            qm: Scalar::zero(),
+            ql: Scalar::zero(),
+            qr: Scalar::zero(),
+            qo: Scalar::one(),
+            qc: -Scalar::one(),
+        };
+
+        let constraint_system = ConstraintSystem {
+            var_num: 80,
+            public_inputs: vec![],
+            logic_constraints: vec![],
+            range_constraints: vec![],
+            sha256_constraints: vec![],
+            merkle_membership_constraints: vec![],
+            schnorr_constraints: vec![constraint],
+            blake2s_constraints: vec![],
+            pedersen_constraints: vec![],
+            hash_to_field_constraints: vec![],
+            constraints: vec![arith_constraint],
+            ecdsa_secp256k1_constraints: vec![],
+            fixed_base_scalar_mul_constraints: vec![],
+        };
+
+        let pub_x =
+            Scalar::from_hex("0x17cbd3ed3151ccfd170efe1d54280a6a4822640bf5c369908ad74ea21518a9c5")
+                .unwrap();
+        let pub_y =
+            Scalar::from_hex("0x0e0456e3795c1a31f20035b741cd6158929eeccd320d299cfcac962865a6bc74")
+                .unwrap();
+
+        let sig: [i128; 64] = [
+            5, 202, 31, 146, 81, 242, 246, 69, 43, 107, 249, 153, 198, 44, 14, 111, 191, 121, 137,
+            166, 160, 103, 18, 181, 243, 233, 226, 95, 67, 16, 37, 128, 85, 76, 19, 253, 30, 77,
+            192, 53, 138, 205, 69, 33, 236, 163, 83, 194, 84, 137, 184, 221, 176, 121, 179, 27, 63,
+            70, 54, 16, 176, 250, 39, 239,
+        ];
+        let mut sig_as_scalars = [Scalar::zero(); 64];
+        for i in 0..64 {
+            sig_as_scalars[i] = sig[i].into()
+        }
+        let message: Vec<Scalar> = vec![
+            0_i128.into(),
+            1_i128.into(),
+            2_i128.into(),
+            3_i128.into(),
+            4_i128.into(),
+            5_i128.into(),
+            6_i128.into(),
+            7_i128.into(),
+            8_i128.into(),
+            9_i128.into(),
+        ];
+        let mut witness_values = Vec::new();
+        witness_values.extend(message);
+        witness_values.push(pub_x);
+        witness_values.push(pub_y);
+        witness_values.extend(&sig_as_scalars);
+        witness_values.push(Scalar::zero());
+
+        let case_1 = WitnessResult {
+            witness: Assignments(witness_values),
+            public_inputs: Assignments::default(),
+            result: true,
+        };
+
+        test_composer_with_pk_vk(constraint_system, vec![case_1]);
+    }
+
+    #[test]
+    fn test_ped_constraints() {
+        let constraint = PedersenConstraint {
+            inputs: vec![1, 2],
+            result_x: 3,
+            result_y: 4,
+        };
+
+        let x_constraint = Constraint {
+            a: 3,
+            b: 3,
+            c: 3,
+            qm: Scalar::zero(),
+            ql: Scalar::one(),
+            qr: Scalar::zero(),
+            qo: Scalar::zero(),
+            qc: -Scalar::from_hex(
+                "0x229fb88be21cec523e9223a21324f2e305aea8bff9cdbcb3d0c6bba384666ea1",
+            )
+            .unwrap(),
+        };
+        let y_constraint = Constraint {
+            a: 4,
+            b: 4,
+            c: 4,
+            qm: Scalar::zero(),
+            ql: Scalar::one(),
+            qr: Scalar::zero(),
+            qo: Scalar::zero(),
+            qc: -Scalar::from_hex(
+                "0x296b4b4605e586a91caa3202baad557628a8c56d0a1d6dff1a7ca35aed3029d5",
+            )
+            .unwrap(),
+        };
+
+        let constraint_system = ConstraintSystem {
+            var_num: 100,
+            public_inputs: vec![],
+            logic_constraints: vec![],
+            range_constraints: vec![],
+            sha256_constraints: vec![],
+            merkle_membership_constraints: vec![],
+            schnorr_constraints: vec![],
+            blake2s_constraints: vec![],
+            pedersen_constraints: vec![constraint],
+            hash_to_field_constraints: vec![],
+            constraints: vec![x_constraint, y_constraint],
+            ecdsa_secp256k1_constraints: vec![],
+            fixed_base_scalar_mul_constraints: vec![],
+        };
+
+        let scalar_0 = Scalar::from_hex("0x00").unwrap();
+        let scalar_1 = Scalar::from_hex("0x01").unwrap();
+
+        let mut witness_values = Vec::new();
+        witness_values.push(scalar_0);
+        witness_values.push(scalar_1);
+        // witness_values.push(Scalar::zero());
+
+        let case_1 = WitnessResult {
+            witness: Assignments(witness_values),
+            public_inputs: Assignments::default(),
+            result: true,
+        };
+
+        test_composer_with_pk_vk(constraint_system, vec![case_1]);
+    }
+
+    #[derive(Clone, Debug)]
+    struct WitnessResult {
+        witness: WitnessAssignments,
+        public_inputs: Assignments,
+        result: bool,
+    }
+
+    fn test_composer_with_pk_vk(
+        constraint_system: ConstraintSystem,
+        test_cases: Vec<WitnessResult>,
+    ) {
+        let mut sc = StandardComposer::new(constraint_system);
+
+        let proving_key = sc.compute_proving_key();
+        let verification_key = sc.compute_verification_key(&proving_key);
+
+        for test_case in test_cases.into_iter() {
+            let proof = sc.create_proof_with_pk(test_case.witness, &proving_key);
+            let verified = sc.verify_with_vk(&proof, test_case.public_inputs, &verification_key);
+            assert_eq!(verified, test_case.result);
+        }
+    }
 }

--- a/barretenberg_wasm/src/pedersen.rs
+++ b/barretenberg_wasm/src/pedersen.rs
@@ -48,6 +48,45 @@ impl Barretenberg {
 }
 
 #[test]
+fn basic_interop() {
+    // Expected values were taken from Barretenberg by running `crypto::pedersen::compress_native`
+    // printing the result in hex to `std::cout` and copying
+    struct Test<'a> {
+        input_left: FieldElement,
+        input_right: FieldElement,
+        expected_hex: &'a str,
+    }
+
+    let tests = vec![
+        Test {
+            input_left: FieldElement::zero(),
+            input_right: FieldElement::one(),
+            expected_hex: "0x229fb88be21cec523e9223a21324f2e305aea8bff9cdbcb3d0c6bba384666ea1",
+        },
+        Test {
+            input_left: FieldElement::one(),
+            input_right: FieldElement::one(),
+            expected_hex: "0x26425ddf29b4af6ee91008e8dbcbee975653170eee849efd75abf8301dee114e",
+        },
+        Test {
+            input_left: FieldElement::one(),
+            input_right: FieldElement::zero(),
+            expected_hex: "0x08f3cb4f0fdd7a9ef130c6d4590af6750b1475161020a198a56eced45078ccf2",
+        },
+    ];
+
+    let mut barretenberg = Barretenberg::new();
+    for test in tests {
+        let expected = FieldElement::from_hex(test.expected_hex).unwrap();
+
+        let got = barretenberg.compress_native(&test.input_left, &test.input_right);
+        let got_many = barretenberg.compress_many(vec![test.input_left, test.input_right]);
+        assert_eq!(got, expected);
+        assert_eq!(got, got_many);
+    }
+}
+
+#[test]
 fn pedersen_hash_to_point() {
     let mut barretenberg = Barretenberg::new();
     let (x, y) = barretenberg.encrypt(vec![FieldElement::zero(), FieldElement::one()]);

--- a/barretenberg_wasm/src/scalar_mul.rs
+++ b/barretenberg_wasm/src/scalar_mul.rs
@@ -19,3 +19,20 @@ impl Barretenberg {
         (pubkey_x, pubkey_y)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn smoke_test() {
+        let mut barretenberg = Barretenberg::new();
+        let input = FieldElement::one();
+
+        let res = barretenberg.fixed_base(&input);
+        let x = "0000000000000000000000000000000000000000000000000000000000000001";
+        let y = "0000000000000002cf135e7506a45d632d270d45f1181294833fc48d823f272c";
+
+        assert_eq!(x, res.0.to_hex());
+        assert_eq!(y, res.1.to_hex());
+    }
+}


### PR DESCRIPTION
This adds additional testing to `barretenberg_wasm`. While working on #84, @vezenovm has to link everything into Noir to run tests to find problems in the wasm. This adds a base layer of tests so we hopefully catch some things before needing to link into Noir.