### PR TITLE
chore!: update to ACVM 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c21590f6da95914f1d83f247dba49d4f287beb725bfbcbc54eaf823484b1a"
+checksum = "193d36487ed35bb7e346437e439cdefb6ae2d61bca65782fb1cc5f8c66e4fe89"
 dependencies = [
  "acir_field",
  "flate2",
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081a09b71facabddd411bfb8459c0f4d9350c39707680da6c04debb3db9de503"
+checksum = "6c91a65102981758a41cdba45613653835660d8e5ff1020c8a156fad12f94d04"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,13 +30,14 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73876b7d5d23d0826ea4c9150b4a62af0b20a6937a79472ee0ceda30868aa207"
+checksum = "94b486b610240761893d8db5e09c69df12b81c3eec8591e9034f270ebe886ec2"
 dependencies = [
  "acir",
  "acvm_stdlib",
  "blake2",
+ "crc32fast",
  "indexmap",
  "k256",
  "num-bigint",
@@ -47,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2259c21b06db652e41bddb1deb22da8d303746a0e8bf877983c7d83f71943b8"
+checksum = "4b7e6ec98492934096c9b5f17057b8ba0689fec2f628ca38a0bf5f6b0b922223"
 dependencies = [
  "acir",
 ]

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -9,42 +9,6 @@ use common::serializer::serialize_circuit;
 use std::collections::BTreeMap;
 
 impl ProofSystemCompiler for Plonk {
-    fn prove_with_meta(
-        &self,
-        circuit: Circuit,
-        witness_values: BTreeMap<Witness, FieldElement>,
-    ) -> Vec<u8> {
-        let constraint_system = serialize_circuit(&circuit);
-
-        let mut composer = StandardComposer::new(constraint_system);
-
-        let proving_key = composer.compute_proving_key();
-
-        let assignments = proof::flatten_witness_map(&circuit, witness_values);
-
-        composer.create_proof_with_pk(assignments, &proving_key)
-    }
-
-    fn verify_from_cs(
-        &self,
-        proof: &[u8],
-        public_inputs: Vec<FieldElement>,
-        circuit: Circuit,
-    ) -> bool {
-        let constraint_system = serialize_circuit(&circuit);
-
-        let mut composer = StandardComposer::new(constraint_system);
-
-        let proving_key = composer.compute_proving_key();
-        let verification_key = composer.compute_verification_key(&proving_key);
-
-        composer.verify_with_vk(
-            proof,
-            Assignments::from_vec(public_inputs),
-            &verification_key,
-        )
-    }
-
     fn np_language(&self) -> Language {
         Language::PLONKCSat { width: 3 }
     }

--- a/barretenberg_static_lib/src/acvm_interop/pwg.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg.rs
@@ -1,6 +1,6 @@
 use common::acvm::acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness};
-use common::acvm::FieldElement;
-use common::acvm::PartialWitnessGenerator;
+use common::acvm::{FieldElement, OpcodeResolution};
+use common::acvm::{OpcodeResolutionError, PartialWitnessGenerator};
 use std::collections::BTreeMap;
 
 mod black_box_functions;
@@ -13,7 +13,7 @@ impl PartialWitnessGenerator for Plonk {
     fn solve_black_box_function_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
-    ) -> Result<(), common::acvm::OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         BlackBoxFuncCaller::solve_black_box_func_call(initial_witness, func_call)
     }
 }

--- a/barretenberg_static_lib/src/acvm_interop/pwg/black_box_functions.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/black_box_functions.rs
@@ -1,7 +1,7 @@
 use crate::Barretenberg;
 
 use common::acvm::acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness};
-use common::acvm::{FieldElement, OpcodeResolutionError};
+use common::acvm::{FieldElement, OpcodeResolution, OpcodeResolutionError};
 use common::black_box_functions::BarretenbergShared;
 use std::collections::BTreeMap;
 
@@ -37,7 +37,7 @@ impl BlackBoxFuncCaller {
     pub(super) fn solve_black_box_func_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gadget_call: &BlackBoxFuncCall,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         common::black_box_functions::solve_black_box_func_call::<Barretenberg>(
             initial_witness,
             gadget_call,

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -10,42 +10,6 @@ use common::serializer::serialize_circuit;
 use std::collections::BTreeMap;
 
 impl ProofSystemCompiler for Plonk {
-    fn prove_with_meta(
-        &self,
-        circuit: Circuit,
-        witness_values: BTreeMap<Witness, FieldElement>,
-    ) -> Vec<u8> {
-        let constraint_system = serialize_circuit(&circuit);
-
-        let mut composer = StandardComposer::new(constraint_system);
-
-        let proving_key = composer.compute_proving_key();
-
-        let assignments = proof::flatten_witness_map(&circuit, witness_values);
-
-        composer.create_proof_with_pk(assignments, &proving_key)
-    }
-
-    fn verify_from_cs(
-        &self,
-        proof: &[u8],
-        public_inputs: Vec<FieldElement>,
-        circuit: Circuit,
-    ) -> bool {
-        let constraint_system = serialize_circuit(&circuit);
-
-        let mut composer = StandardComposer::new(constraint_system);
-
-        let proving_key = composer.compute_proving_key();
-        let verification_key = composer.compute_verification_key(&proving_key);
-
-        composer.verify_with_vk(
-            proof,
-            Assignments::from_vec(public_inputs),
-            &verification_key,
-        )
-    }
-
     fn np_language(&self) -> Language {
         Language::PLONKCSat { width: 3 }
     }

--- a/barretenberg_wasm/src/acvm_interop/pwg.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg.rs
@@ -1,6 +1,6 @@
 use common::acvm::acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness};
-use common::acvm::FieldElement;
-use common::acvm::PartialWitnessGenerator;
+use common::acvm::{FieldElement, OpcodeResolution};
+use common::acvm::{OpcodeResolutionError, PartialWitnessGenerator};
 use std::collections::BTreeMap;
 
 mod black_box_functions;
@@ -13,7 +13,7 @@ impl PartialWitnessGenerator for Plonk {
     fn solve_black_box_function_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
-    ) -> Result<(), common::acvm::OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         BlackBoxFuncCaller::solve_black_box_func_call(initial_witness, func_call)
     }
 }

--- a/barretenberg_wasm/src/acvm_interop/pwg/black_box_functions.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/black_box_functions.rs
@@ -1,7 +1,7 @@
 use crate::Barretenberg;
 
 use common::acvm::acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness};
-use common::acvm::{FieldElement, OpcodeResolutionError};
+use common::acvm::{FieldElement, OpcodeResolution, OpcodeResolutionError};
 use common::black_box_functions::BarretenbergShared;
 use std::collections::BTreeMap;
 
@@ -37,7 +37,7 @@ impl BlackBoxFuncCaller {
     pub(super) fn solve_black_box_func_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gadget_call: &BlackBoxFuncCall,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         common::black_box_functions::solve_black_box_func_call::<Barretenberg>(
             initial_witness,
             gadget_call,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { version = "0.6.0", features = ["bn254"] }
+acvm = { version = "0.7.0", features = ["bn254"] }
 
 sled = "0.34.6"
 blake2 = "0.9.1"

--- a/common/src/black_box_functions.rs
+++ b/common/src/black_box_functions.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use acvm::{
     acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc},
     pwg::{self, witness_to_value},
-    FieldElement, OpcodeResolutionError,
+    FieldElement, OpcodeResolution, OpcodeResolutionError,
 };
 use blake2::{Blake2s, Digest};
 
@@ -27,7 +27,7 @@ pub trait BarretenbergShared: PathHasher {
 pub fn solve_black_box_func_call<B: BarretenbergShared>(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     gadget_call: &BlackBoxFuncCall,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
     match gadget_call.name {
         BlackBoxFunc::SHA256 => pwg::hash::sha256(initial_witness, gadget_call),
         BlackBoxFunc::Blake2s => pwg::hash::blake2s(initial_witness, gadget_call),
@@ -157,5 +157,6 @@ pub fn solve_black_box_func_call<B: BarretenbergShared>(
         }
         BlackBoxFunc::RANGE => acvm::pwg::range::solve_range_opcode(initial_witness, gadget_call)?,
     }
-    Ok(())
+
+    Ok(OpcodeResolution::Solved)
 }

--- a/common/src/serializer.rs
+++ b/common/src/serializer.rs
@@ -341,8 +341,8 @@ pub fn serialize_circuit(circuit: &Circuit) -> ConstraintSystem {
             Opcode::Directive(_) => {
                 // Directives are only needed by the pwg
             }
-            Opcode::Block(_, _) => {
-                // TODO: implement serialization of blocks to match BB's interface
+            Opcode::Block(_) | Opcode::RAM(_) | Opcode::ROM(_) | Opcode::Oracle(_) => {
+                // TODO: implement serialization to match BB's interface
             }
         }
     }
@@ -350,7 +350,7 @@ pub fn serialize_circuit(circuit: &Circuit) -> ConstraintSystem {
     // Create constraint system
     ConstraintSystem {
         var_num: circuit.current_witness_index + 1, // number of witnesses is the witness index + 1;
-        public_inputs: circuit.public_inputs.indices(),
+        public_inputs: circuit.public_inputs().indices(),
         logic_constraints,
         range_constraints,
         sha256_constraints,


### PR DESCRIPTION
This PR updates us to use ACVM 0.7.0.

Two things to take note of are
- `solve_black_box_func_call` must never return `OpcodeResolutionError::OpcodeNotSolvable`. I can't find any references to this in this repo so this should be safe.
- I'm not entirely sure how we want to handle serialisation of the new opcodes so I've added them to the TODO which we have for block opcodes.