### PR TITLE
chore: reenable commented out test cases

### DIFF
--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -331,9 +331,7 @@ mod test {
             public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
             result: false,
         };
-        let test_cases = vec![
-            /*case_1,*/ case_2, case_3, /*case_4,*/ case_5, case_6,
-        ];
+        let test_cases = vec![case_1, case_2, case_3, case_4, case_5, case_6];
 
         test_composer_with_pk_vk(constraint_system, test_cases);
     }

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -343,10 +343,12 @@ mod test {
             fixed_base_scalar_mul_constraints: vec![],
         };
 
+        // TODO: test cases 1 and 4 fail despite passing in `barretenberg_static_lib`
+
         // This fails because the constraint system requires public inputs,
         // but none are supplied in public_inputs. So the verifier will not
         // supply anything.
-        let case_1 = WitnessResult {
+        let _case_1 = WitnessResult {
             witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
             public_inputs: Assignments::default(),
             result: false,
@@ -364,7 +366,7 @@ mod test {
         };
 
         // Not enough public inputs
-        let case_4 = WitnessResult {
+        let _case_4 = WitnessResult {
             witness: Assignments(vec![
                 Scalar::one(),
                 Scalar::from(2_i128),


### PR DESCRIPTION
We're throwing warnings due to unused variables in the tests. I've then reenabled these tests where possible and dealt with the warnings where the tests fail. (I don't have context on why these test cases fail but I assume that they were commented out due to failing.)

I'll add an issue for the failing tests once this is merged.