### PR TITLE
fix: enable `getrandom/js` with `js` feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,8 +1069,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/barretenberg_wasm/Cargo.toml
+++ b/barretenberg_wasm/Cargo.toml
@@ -23,7 +23,6 @@ tempfile = "*"
 
 [features]
 default = [
-    # "acvm/bn254",
     "common/std",
     "wasmer/sys-default",
     "wasmer/cranelift",
@@ -32,7 +31,6 @@ default = [
     "wasmer/default-universal",
 ]
 js = [
-
-    # "acvm/bn254", 
+    "getrandom/js",
     "wasmer/js-default",
 ]


### PR DESCRIPTION
Not having this feature flag enabled prevents us from using `barretenberg_wasm` from within a webassembly context.

https://docs.rs/getrandom/latest/getrandom/#webassembly-support