### PR TITLE
feat: replace `downloader` dependency with `reqwest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,11 @@ dependencies = [
  "acvm",
  "blake2",
  "dirs 3.0.2",
- "downloader",
+ "futures-util",
  "indicatif",
+ "reqwest",
  "sled",
+ "tokio",
 ]
 
 [[package]]
@@ -774,19 +776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downloader"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
-dependencies = [
- "futures",
- "rand",
- "reqwest",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,28 +944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
-name = "futures"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -984,17 +957,6 @@ name = "futures-core"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1031,7 +993,6 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1297,14 +1258,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
- "regex",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1574,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -1625,7 +1586,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -1640,6 +1611,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1686,6 +1670,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -1767,7 +1757,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core 0.6.4",
 ]
@@ -1793,9 +1782,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "rayon"
@@ -1927,10 +1913,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -2226,6 +2214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,7 +2254,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -2394,9 +2391,23 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2661,6 +2672,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,17 +1586,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1611,19 +1601,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1885,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64",
  "bytes",
@@ -2214,15 +2191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,7 +2222,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2265,9 +2233,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -2381,33 +2349,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
- "num_cpus",
- "parking_lot 0.12.1",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/barretenberg_static_lib/src/crs.rs
+++ b/barretenberg_static_lib/src/crs.rs
@@ -22,5 +22,6 @@ fn downloading() {
     let dir = tempdir().unwrap();
 
     let file_path = dir.path().to_path_buf().join("transcript00.dat");
-    download_crs(file_path);
+    let res = download_crs(file_path);
+    assert_eq!(res, Ok(()));
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,13 +15,11 @@ acvm = { version = "0.9.0", features = ["bn254"] }
 sled = "0.34.6"
 blake2 = "0.9.1"
 dirs = { version = "3.0", optional = true }
-reqwest = { version = "0.11.3", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
-tokio = { version = "1", optional = true, features=["full"] }
+reqwest = { version = "0.11.16", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
+tokio = { version = "1.0", optional = true }
 futures-util = { version = "0.3.14", optional = true }
 indicatif = { version = "0.17.3", optional = true }
 
 [features]
-# This feature flag is here because we cannot compile
-# the downloader dependency with the wasm32 target
 default = ["std"]
 std = ["dep:reqwest", "dep:tokio", "dep:futures-util", "dep:dirs", "dep:indicatif"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,11 +15,13 @@ acvm = { version = "0.9.0", features = ["bn254"] }
 sled = "0.34.6"
 blake2 = "0.9.1"
 dirs = { version = "3.0", optional = true }
-downloader = { version = "0.2.7", optional = true, default-features = false, features = ["rustls-tls"] }
-indicatif = { version = "0.15.0", optional = true }
+reqwest = { version = "0.11.3", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
+tokio = { version = "1", optional = true, features=["full"] }
+futures-util = { version = "0.3.14", optional = true }
+indicatif = { version = "0.17.3", optional = true }
 
 [features]
 # This feature flag is here because we cannot compile
 # the downloader dependency with the wasm32 target
 default = ["std"]
-std = ["dep:downloader", "dep:dirs", "dep:indicatif"]
+std = ["dep:reqwest", "dep:tokio", "dep:futures-util", "dep:dirs", "dep:indicatif"]

--- a/common/src/crs.rs
+++ b/common/src/crs.rs
@@ -142,7 +142,7 @@ async fn download_crs_async(path_to_transcript: PathBuf) -> Result<(), String> {
     ))?;
 
     // Indicatif setup
-    use indicatif::{ProgressBar, ProgressStyle};
+    use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
     let pb = ProgressBar::new(total_size).with_style(
         ProgressStyle::default_bar()
             .template("[{elapsed_precise}] {bar:40.cyan/blue} {bytes:>7}/{total_bytes:7} {msg}")
@@ -160,7 +160,10 @@ async fn download_crs_async(path_to_transcript: PathBuf) -> Result<(), String> {
     })?;
     let mut stream = res.bytes_stream();
 
-    println!("\nDownloading the Ignite SRS (340MB)\n");
+    println!(
+        "\nDownloading the Ignite SRS ({})\n",
+        HumanBytes(total_size)
+    );
     while let Some(item) = stream.next().await {
         let chunk = item.map_err(|_| "Error while downloading file".to_string())?;
         file.write_all(&chunk)

--- a/common/src/crs.rs
+++ b/common/src/crs.rs
@@ -1,4 +1,6 @@
-use std::{env, path::PathBuf};
+use std::{env, fs::File, io::Write, path::PathBuf};
+
+use futures_util::StreamExt;
 
 // TODO(blaine): Use manifest parsing in BB instead of hardcoding these
 const G1_START: usize = 28;
@@ -7,6 +9,8 @@ const G2_END: usize = G2_START + 128 - 1;
 
 const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 const TRANSCRIPT_NAME: &str = "transcript00.dat";
+const TRANSCRIPT_URL: &str =
+    "http://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/monomial/transcript00.dat";
 
 fn transcript_location() -> PathBuf {
     match env::var("BARRETENBERG_TRANSCRIPT") {
@@ -35,13 +39,13 @@ impl CRS {
 
         // If the CRS does not exist, then download it from S3
         if !transcript_location().exists() {
-            download_crs(transcript_location());
+            download_crs(transcript_location()).unwrap();
         }
 
         // Read CRS, if it's incomplete, download it
         let mut crs = read_crs(transcript_location());
         if crs.len() < G2_END + 1 {
-            download_crs(transcript_location());
+            download_crs(transcript_location()).unwrap();
             crs = read_crs(transcript_location());
         }
 
@@ -66,13 +70,13 @@ impl G2 {
     pub fn new() -> G2 {
         // If the CRS does not exist, then download it from S3
         if !transcript_location().exists() {
-            download_crs(transcript_location());
+            download_crs(transcript_location()).unwrap();
         }
 
         // Read CRS, if it's incomplete, download it
         let mut crs = read_crs(transcript_location());
         if crs.len() < G2_END + 1 {
-            download_crs(transcript_location());
+            download_crs(transcript_location()).unwrap();
             crs = read_crs(transcript_location());
         }
 
@@ -106,91 +110,68 @@ fn read_crs(path: PathBuf) -> Vec<u8> {
 
 // XXX: Below is the logic to download the CRS if it is not already present
 
-pub fn download_crs(mut path_to_transcript: PathBuf) {
+pub fn download_crs(path_to_transcript: PathBuf) -> Result<(), String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(download_crs_async(path_to_transcript))
+}
+
+async fn download_crs_async(path_to_transcript: PathBuf) -> Result<(), String> {
     // Remove old crs
     if path_to_transcript.exists() {
         let _ = std::fs::remove_file(path_to_transcript.as_path());
     }
+
     // Pop off the transcript component to get just the directory
-    path_to_transcript.pop();
+    let transcript_dir = path_to_transcript
+        .parent()
+        .expect("transcript file should have parent");
 
-    if !path_to_transcript.exists() {
-        std::fs::create_dir_all(&path_to_transcript).unwrap();
+    if !transcript_dir.exists() {
+        std::fs::create_dir_all(transcript_dir).unwrap();
     }
 
-    let url = "http://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/monomial/transcript00.dat";
-    use downloader::Downloader;
-    let mut downloader = Downloader::builder()
-        .download_folder(path_to_transcript.as_path())
-        .build()
-        .unwrap();
+    let res = reqwest::get(TRANSCRIPT_URL)
+        .await
+        .map_err(|err| format!("Failed to GET from '{}' ({})", TRANSCRIPT_URL, err))?;
+    let total_size = res.content_length().ok_or(format!(
+        "Failed to get content length from '{}'",
+        TRANSCRIPT_URL
+    ))?;
 
-    let dl = downloader::Download::new(url);
-    let dl = dl.file_name(&PathBuf::from(TRANSCRIPT_NAME));
-    let dl = dl.progress(SimpleReporter::create());
-    let result = downloader.download(&[dl]).unwrap();
+    // Indicatif setup
+    use indicatif::{ProgressBar, ProgressStyle};
+    let pb = ProgressBar::new(total_size).with_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] {bar:40.cyan/blue} {bytes:>7}/{total_bytes:7} {msg}")
+            .unwrap()
+            .progress_chars("##-"),
+    );
 
-    for r in result {
-        match r {
-            Err(e) => println!("Error: {e}"),
-            Ok(s) => println!("\nSRS is located at : {:?}", &s.file_name),
-        };
+    // download chunks
+    let mut file = File::create(path_to_transcript.clone()).map_err(|err| {
+        format!(
+            "Failed to create file '{}' ({})",
+            path_to_transcript.display(),
+            err
+        )
+    })?;
+    let mut stream = res.bytes_stream();
+
+    println!("\nDownloading the Ignite SRS (340MB)\n");
+    while let Some(item) = stream.next().await {
+        let chunk = item.map_err(|_| "Error while downloading file".to_string())?;
+        file.write_all(&chunk)
+            .map_err(|_| "Error while writing to file".to_string())?;
+        pb.inc(chunk.len() as u64);
     }
-}
-// Taken from https://github.com/hunger/downloader/blob/main/examples/download.rs
-struct SimpleReporterPrivate {
-    started: std::time::Instant,
-    progress_bar: indicatif::ProgressBar,
-}
-struct SimpleReporter {
-    private: std::sync::Mutex<Option<SimpleReporterPrivate>>,
-}
+    pb.finish_with_message("Downloaded the SRS successfully!\n");
 
-impl SimpleReporter {
-    fn create() -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self {
-            private: std::sync::Mutex::new(None),
-        })
-    }
-}
+    println!("SRS is located at: {:?}", &path_to_transcript);
 
-impl downloader::progress::Reporter for SimpleReporter {
-    fn setup(&self, max_progress: Option<u64>, _message: &str) {
-        let bar = indicatif::ProgressBar::new(max_progress.unwrap());
-        bar.set_style(
-            indicatif::ProgressStyle::default_bar()
-                .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
-                .progress_chars("##-"),
-        );
-
-        let private = SimpleReporterPrivate {
-            started: std::time::Instant::now(),
-            progress_bar: bar,
-        };
-        println!("\nDownloading the Ignite SRS (340MB)\n");
-
-        let mut guard = self.private.lock().unwrap();
-        *guard = Some(private);
-    }
-
-    fn progress(&self, current: u64) {
-        if let Some(p) = self.private.lock().unwrap().as_mut() {
-            p.progress_bar.set_position(current);
-        }
-    }
-
-    fn set_message(&self, _message: &str) {}
-
-    fn done(&self) {
-        let mut guard = self.private.lock().unwrap();
-        let p = guard.as_mut().unwrap();
-        p.progress_bar.finish();
-        println!("Downloaded the SRS successfully!");
-        println!(
-            "Time Elapsed: {}",
-            indicatif::HumanDuration(p.started.elapsed())
-        );
-    }
+    Ok(())
 }
 
 // #[test]

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
         "QECC",
         "QLOGIC",
         "QRANGE",
+        "reqwest",
         "rollups",
         "schnorr",
         "secp",


### PR DESCRIPTION
This PR replaces `downloader` with `reqwest`

This results in the progress bar being displayed as below:
```
// Downloader
Downloading the Ignite SRS (340MB)

[00:00:17] ######################################## 322560348/322560348 
Downloaded the SRS successfully!
Time Elapsed: 17 seconds

// Reqwest
Downloading the Ignite SRS (340MB)

[00:00:17] ######################################## 307.62 MiB/307.62 MiB Downloaded the SRS successfully!
SRS is located at: "/home/tom/.nargo/backends/acvm-backend-barretenberg/transcript00.dat"
```

The "Downloaded the SRS successfully!" message only appears on completion of the download. I've removed the "Time Elapsed" line as this is displayed in the progress bar.

Resolves #47 