### PR TITLE
fix!: avoid exposing internals of Assignments type

### DIFF
--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -196,7 +196,7 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![]),
+            witness: vec![].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
@@ -235,27 +235,27 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
+            witness: vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::zero()]),
+            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::zero()].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
         let case_3 = WitnessResult {
-            witness: Assignments(vec![10_i128.into(), (-3_i128).into(), 7_i128.into()]),
+            witness: vec![10_i128.into(), (-3_i128).into(), 7_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
         let case_4 = WitnessResult {
-            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::one()]),
+            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::one()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
         let case_5 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 6_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 6_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
@@ -296,42 +296,38 @@ mod test {
         // but none are supplied in public_inputs. So the verifier will not
         // supply anything.
         let _case_1 = WitnessResult {
-            witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
+            witness: vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::zero()]),
-            public_inputs: Assignments(vec![Scalar::zero(), Scalar::zero()]),
+            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::zero()].into(),
+            public_inputs: vec![Scalar::zero(), Scalar::zero()].into(),
             result: true,
         };
 
         let case_3 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 6_i128.into()]),
-            public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 6_i128.into()].into(),
+            public_inputs: vec![Scalar::one(), 3_i128.into()].into(),
             result: false,
         };
 
         // Not enough public inputs
         let _case_4 = WitnessResult {
-            witness: Assignments(vec![
-                Scalar::one(),
-                Scalar::from(2_i128),
-                Scalar::from(6_i128),
-            ]),
-            public_inputs: Assignments(vec![Scalar::one()]),
+            witness: vec![Scalar::one(), Scalar::from(2_i128), Scalar::from(6_i128)].into(),
+            public_inputs: vec![Scalar::one()].into(),
             result: false,
         };
 
         let case_5 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 3_i128.into()]),
-            public_inputs: Assignments(vec![Scalar::one(), 2_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![Scalar::one(), 2_i128.into()].into(),
             result: true,
         };
 
         let case_6 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 3_i128.into()]),
-            public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![Scalar::one(), 3_i128.into()].into(),
             result: false,
         };
         let test_cases = vec![
@@ -381,23 +377,13 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![
-                1_i128.into(),
-                1_i128.into(),
-                2_i128.into(),
-                3_i128.into(),
-            ]),
-            public_inputs: Assignments(vec![Scalar::one()]),
+            witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![Scalar::one()].into(),
             result: true,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![
-                1_i128.into(),
-                1_i128.into(),
-                2_i128.into(),
-                13_i128.into(),
-            ]),
-            public_inputs: Assignments(vec![Scalar::one()]),
+            witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 13_i128.into()].into(),
+            public_inputs: vec![Scalar::one()].into(),
             result: false,
         };
 
@@ -484,7 +470,7 @@ mod test {
         witness_values.push(Scalar::zero());
 
         let case_1 = WitnessResult {
-            witness: Assignments(witness_values),
+            witness: witness_values.into(),
             public_inputs: Assignments::default(),
             result: true,
         };
@@ -548,7 +534,7 @@ mod test {
         let witness_values = vec![scalar_0, scalar_1];
 
         let case_1 = WitnessResult {
-            witness: Assignments(witness_values),
+            witness: witness_values.into(),
             public_inputs: Assignments::default(),
             result: true,
         };

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -263,7 +263,7 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![]),
+            witness: vec![].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
@@ -302,27 +302,27 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
+            witness: vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::zero()]),
+            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::zero()].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
         let case_3 = WitnessResult {
-            witness: Assignments(vec![10_i128.into(), (-3_i128).into(), 7_i128.into()]),
+            witness: vec![10_i128.into(), (-3_i128).into(), 7_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: true,
         };
         let case_4 = WitnessResult {
-            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::one()]),
+            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::one()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
         let case_5 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 6_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 6_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
@@ -363,42 +363,38 @@ mod test {
         // but none are supplied in public_inputs. So the verifier will not
         // supply anything.
         let _case_1 = WitnessResult {
-            witness: Assignments(vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()]),
+            witness: vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![Scalar::zero(), Scalar::zero(), Scalar::zero()]),
-            public_inputs: Assignments(vec![Scalar::zero(), Scalar::zero()]),
+            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::zero()].into(),
+            public_inputs: vec![Scalar::zero(), Scalar::zero()].into(),
             result: true,
         };
 
         let case_3 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 6_i128.into()]),
-            public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 6_i128.into()].into(),
+            public_inputs: vec![Scalar::one(), 3_i128.into()].into(),
             result: false,
         };
 
         // Not enough public inputs
         let _case_4 = WitnessResult {
-            witness: Assignments(vec![
-                Scalar::one(),
-                Scalar::from(2_i128),
-                Scalar::from(6_i128),
-            ]),
-            public_inputs: Assignments(vec![Scalar::one()]),
+            witness: vec![Scalar::one(), Scalar::from(2_i128), Scalar::from(6_i128)].into(),
+            public_inputs: vec![Scalar::one()].into(),
             result: false,
         };
 
         let case_5 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 3_i128.into()]),
-            public_inputs: Assignments(vec![Scalar::one(), 2_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![Scalar::one(), 2_i128.into()].into(),
             result: true,
         };
 
         let case_6 = WitnessResult {
-            witness: Assignments(vec![Scalar::one(), 2_i128.into(), 3_i128.into()]),
-            public_inputs: Assignments(vec![Scalar::one(), 3_i128.into()]),
+            witness: vec![Scalar::one(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![Scalar::one(), 3_i128.into()].into(),
             result: false,
         };
         let test_cases = vec![
@@ -448,23 +444,13 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![
-                1_i128.into(),
-                1_i128.into(),
-                2_i128.into(),
-                3_i128.into(),
-            ]),
-            public_inputs: Assignments(vec![Scalar::one()]),
+            witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![Scalar::one()].into(),
             result: true,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![
-                1_i128.into(),
-                1_i128.into(),
-                2_i128.into(),
-                13_i128.into(),
-            ]),
-            public_inputs: Assignments(vec![Scalar::one()]),
+            witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 13_i128.into()].into(),
+            public_inputs: vec![Scalar::one()].into(),
             result: false,
         };
 
@@ -551,7 +537,7 @@ mod test {
         witness_values.push(Scalar::zero());
 
         let case_1 = WitnessResult {
-            witness: Assignments(witness_values),
+            witness: witness_values.into(),
             public_inputs: Assignments::default(),
             result: true,
         };
@@ -615,7 +601,7 @@ mod test {
         let witness_values = vec![scalar_0, scalar_1];
 
         let case_1 = WitnessResult {
-            witness: Assignments(witness_values),
+            witness: witness_values.into(),
             public_inputs: Assignments::default(),
             result: true,
         };

--- a/barretenberg_wasm/src/pedersen.rs
+++ b/barretenberg_wasm/src/pedersen.rs
@@ -19,7 +19,7 @@ impl Barretenberg {
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
     pub fn compress_many(&mut self, inputs: Vec<FieldElement>) -> FieldElement {
-        let input_buf = Assignments(inputs).to_bytes();
+        let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf);
 
         self.call_multiple(
@@ -32,7 +32,7 @@ impl Barretenberg {
     }
 
     pub fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
-        let input_buf = Assignments(inputs).to_bytes();
+        let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf);
 
         let result_ptr = Value::I32(32);

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -1,8 +1,15 @@
 pub use acvm::FieldElement as Scalar;
 
 #[derive(Debug, Clone)]
-pub struct Assignments(pub Vec<Scalar>);
+pub struct Assignments(Vec<Scalar>);
 pub type WitnessAssignments = Assignments;
+
+// This is a separate impl so the constructor can get the wasm_bindgen macro in the future
+impl Assignments {
+    pub fn new() -> Assignments {
+        Assignments(vec![])
+    }
+}
 
 impl Assignments {
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -28,8 +35,24 @@ impl Assignments {
     pub fn push(&mut self, value: Scalar) {
         self.0.push(value);
     }
-    pub fn new() -> Assignments {
-        Assignments(vec![])
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl IntoIterator for Assignments {
+    type Item = Scalar;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl From<Vec<Scalar>> for Assignments {
+    fn from(w: Vec<Scalar>) -> Assignments {
+        Assignments(w)
     }
 }
 

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -16,12 +16,11 @@ pub fn remove_public_inputs(num_pub_inputs: usize, proof: &[u8]) -> Vec<u8> {
 }
 
 pub fn prepend_public_inputs(proof: Vec<u8>, public_inputs: Assignments) -> Vec<u8> {
-    if public_inputs.0.is_empty() {
+    if public_inputs.is_empty() {
         return proof;
     }
 
     let public_inputs_bytes = public_inputs
-        .0
         .into_iter()
         .flat_map(|assignment| assignment.to_be_bytes());
 


### PR DESCRIPTION
This change removes the `pub Vec<Scalar>` internals of the `Assignments` type. It then adds some utilities that are needed to stop reaching into the internals. I also cleaned up the tests by using `into()`

This will help us add wasm_bindgen to it in the future.