### PR TITLE
feat!: Implement pseudo-builder pattern for ConstraintSystem & hide struct fields

### DIFF
--- a/barretenberg_static_lib/src/acvm_interop/smart_contract.rs
+++ b/barretenberg_static_lib/src/acvm_interop/smart_contract.rs
@@ -43,21 +43,10 @@ fn test_smart_contract() {
         qc: Scalar::zero(),
     };
 
-    let constraint_system = ConstraintSystem {
-        var_num: 4,
-        public_inputs: vec![1, 2],
-        logic_constraints: vec![],
-        range_constraints: vec![],
-        sha256_constraints: vec![],
-        merkle_membership_constraints: vec![],
-        schnorr_constraints: vec![],
-        blake2s_constraints: vec![],
-        pedersen_constraints: vec![],
-        hash_to_field_constraints: vec![],
-        constraints: vec![constraint],
-        ecdsa_secp256k1_constraints: vec![],
-        fixed_base_scalar_mul_constraints: vec![],
-    };
+    let constraint_system = ConstraintSystem::new()
+        .var_num(4)
+        .public_inputs(vec![1, 2])
+        .constraints(vec![constraint]);
 
     let sc = StandardComposer::new(constraint_system);
 

--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -133,7 +133,7 @@ impl StandardComposer {
         unsafe {
             result = Vec::from_raw_parts(proof_addr, proof_size, proof_size);
         }
-        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), &result)
+        proof::remove_public_inputs(self.constraint_system.public_inputs_size(), &result)
     }
 
     pub fn verify_with_vk(
@@ -179,21 +179,7 @@ mod test {
 
     #[test]
     fn test_no_constraints_no_pub_inputs() {
-        let constraint_system = ConstraintSystem {
-            var_num: 4,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new();
 
         let case_1 = WitnessResult {
             witness: vec![].into(),
@@ -218,21 +204,9 @@ mod test {
             qc: Scalar::zero(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 4,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(4)
+            .constraints(vec![constraint]);
 
         let case_1 = WitnessResult {
             witness: vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()].into(),
@@ -276,21 +250,10 @@ mod test {
             qc: Scalar::zero(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 4,
-            public_inputs: vec![1, 2],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(4)
+            .public_inputs(vec![1, 2])
+            .constraints(vec![constraint]);
 
         // This fails because the constraint system requires public inputs,
         // but none are supplied in public_inputs. So the verifier will not
@@ -360,21 +323,10 @@ mod test {
             qc: Scalar::one(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 5,
-            public_inputs: vec![1],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![constraint, constraint2],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(5)
+            .public_inputs(vec![1])
+            .constraints(vec![constraint, constraint2]);
 
         let case_1 = WitnessResult {
             witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 3_i128.into()].into(),
@@ -417,21 +369,10 @@ mod test {
             qc: -Scalar::one(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 80,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![constraint],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![arith_constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(80)
+            .schnorr_constraints(vec![constraint])
+            .constraints(vec![arith_constraint]);
 
         let pub_x =
             Scalar::from_hex("0x17cbd3ed3151ccfd170efe1d54280a6a4822640bf5c369908ad74ea21518a9c5")
@@ -513,21 +454,10 @@ mod test {
             .unwrap(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 100,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![constraint],
-            hash_to_field_constraints: vec![],
-            constraints: vec![x_constraint, y_constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(100)
+            .pedersen_constraints(vec![constraint])
+            .constraints(vec![x_constraint, y_constraint]);
 
         let scalar_0 = Scalar::from_hex("0x00").unwrap();
         let scalar_1 = Scalar::from_hex("0x01").unwrap();

--- a/barretenberg_wasm/src/acvm_interop/smart_contract.rs
+++ b/barretenberg_wasm/src/acvm_interop/smart_contract.rs
@@ -51,21 +51,10 @@ fn test_smart_contract() {
         qc: Scalar::zero(),
     };
 
-    let constraint_system = ConstraintSystem {
-        var_num: 4,
-        public_inputs: vec![1, 2],
-        logic_constraints: vec![],
-        range_constraints: vec![],
-        sha256_constraints: vec![],
-        merkle_membership_constraints: vec![],
-        schnorr_constraints: vec![],
-        blake2s_constraints: vec![],
-        pedersen_constraints: vec![],
-        hash_to_field_constraints: vec![],
-        constraints: vec![constraint],
-        ecdsa_secp256k1_constraints: vec![],
-        fixed_base_scalar_mul_constraints: vec![],
-    };
+    let constraint_system = ConstraintSystem::new()
+        .var_num(4)
+        .public_inputs(vec![1, 2])
+        .constraints(vec![constraint]);
 
     let mut sc = StandardComposer::new(constraint_system);
 

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -161,7 +161,7 @@ impl StandardComposer {
             proof_ptr as usize,
             proof_ptr as usize + proof_size.unwrap_i32() as usize,
         );
-        proof::remove_public_inputs(self.constraint_system.public_inputs.len(), &proof)
+        proof::remove_public_inputs(self.constraint_system.public_inputs_size(), &proof)
     }
 
     pub fn verify_with_vk(
@@ -228,21 +228,7 @@ mod test {
 
     #[test]
     fn test_no_constraints_no_pub_inputs() {
-        let constraint_system = ConstraintSystem {
-            var_num: 0,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new();
 
         let case_1 = WitnessResult {
             witness: vec![].into(),
@@ -267,21 +253,9 @@ mod test {
             qc: Scalar::zero(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 4,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(4)
+            .constraints(vec![constraint]);
 
         let case_1 = WitnessResult {
             witness: vec![(-1_i128).into(), 2_i128.into(), 1_i128.into()].into(),
@@ -325,21 +299,10 @@ mod test {
             qc: Scalar::zero(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 4,
-            public_inputs: vec![1, 2],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(4)
+            .public_inputs(vec![1, 2])
+            .constraints(vec![constraint]);
 
         // This fails because the constraint system requires public inputs,
         // but none are supplied in public_inputs. So the verifier will not
@@ -409,21 +372,10 @@ mod test {
             qc: Scalar::one(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 5,
-            public_inputs: vec![1],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![constraint, constraint2],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(5)
+            .public_inputs(vec![1])
+            .constraints(vec![constraint, constraint2]);
 
         let case_1 = WitnessResult {
             witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 3_i128.into()].into(),
@@ -466,21 +418,10 @@ mod test {
             qc: -Scalar::one(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 80,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![constraint],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![],
-            hash_to_field_constraints: vec![],
-            constraints: vec![arith_constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(80)
+            .schnorr_constraints(vec![constraint])
+            .constraints(vec![arith_constraint]);
 
         let pub_x =
             Scalar::from_hex("0x17cbd3ed3151ccfd170efe1d54280a6a4822640bf5c369908ad74ea21518a9c5")
@@ -562,21 +503,10 @@ mod test {
             .unwrap(),
         };
 
-        let constraint_system = ConstraintSystem {
-            var_num: 100,
-            public_inputs: vec![],
-            logic_constraints: vec![],
-            range_constraints: vec![],
-            sha256_constraints: vec![],
-            merkle_membership_constraints: vec![],
-            schnorr_constraints: vec![],
-            blake2s_constraints: vec![],
-            pedersen_constraints: vec![constraint],
-            hash_to_field_constraints: vec![],
-            constraints: vec![x_constraint, y_constraint],
-            ecdsa_secp256k1_constraints: vec![],
-            fixed_base_scalar_mul_constraints: vec![],
-        };
+        let constraint_system = ConstraintSystem::new()
+            .var_num(100)
+            .pedersen_constraints(vec![constraint])
+            .constraints(vec![x_constraint, y_constraint]);
 
         let scalar_0 = Scalar::from_hex("0x00").unwrap();
         let scalar_1 = Scalar::from_hex("0x01").unwrap();

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -388,12 +388,16 @@ pub struct ConstraintSystem {
     constraints: Vec<Constraint>,
 }
 
-// Builder-style impl, but we use all data types that can be defaulted so we don't need a separate builder struct
+// This is a separate impl so the constructor can get the wasm_bindgen macro in the future
 impl ConstraintSystem {
     pub fn new() -> Self {
         ConstraintSystem::default()
     }
+}
 
+// Builder-style impl, but we use all data types that can be defaulted so we don't need a separate builder struct
+// TODO(blaine): Add #[cfg(test)] once this project is merged into a single crate
+impl ConstraintSystem {
     pub fn var_num(mut self, var_num: u32) -> Self {
         self.var_num = var_num;
         self

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -370,25 +370,113 @@ impl LogicConstraint {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Default)]
 pub struct ConstraintSystem {
-    pub var_num: u32,
-    pub public_inputs: Vec<u32>,
+    var_num: u32,
+    public_inputs: Vec<u32>,
 
-    pub logic_constraints: Vec<LogicConstraint>,
-    pub range_constraints: Vec<RangeConstraint>,
-    pub sha256_constraints: Vec<Sha256Constraint>,
-    pub merkle_membership_constraints: Vec<MerkleMembershipConstraint>,
-    pub schnorr_constraints: Vec<SchnorrConstraint>,
-    pub ecdsa_secp256k1_constraints: Vec<EcdsaConstraint>,
-    pub blake2s_constraints: Vec<Blake2sConstraint>,
-    pub pedersen_constraints: Vec<PedersenConstraint>,
-    pub hash_to_field_constraints: Vec<HashToFieldConstraint>,
-    pub fixed_base_scalar_mul_constraints: Vec<FixedBaseScalarMulConstraint>,
-    pub constraints: Vec<Constraint>,
+    logic_constraints: Vec<LogicConstraint>,
+    range_constraints: Vec<RangeConstraint>,
+    sha256_constraints: Vec<Sha256Constraint>,
+    merkle_membership_constraints: Vec<MerkleMembershipConstraint>,
+    schnorr_constraints: Vec<SchnorrConstraint>,
+    ecdsa_secp256k1_constraints: Vec<EcdsaConstraint>,
+    blake2s_constraints: Vec<Blake2sConstraint>,
+    pedersen_constraints: Vec<PedersenConstraint>,
+    hash_to_field_constraints: Vec<HashToFieldConstraint>,
+    fixed_base_scalar_mul_constraints: Vec<FixedBaseScalarMulConstraint>,
+    constraints: Vec<Constraint>,
+}
+
+// Builder-style impl, but we use all data types that can be defaulted so we don't need a separate builder struct
+impl ConstraintSystem {
+    pub fn new() -> Self {
+        ConstraintSystem::default()
+    }
+
+    pub fn var_num(mut self, var_num: u32) -> Self {
+        self.var_num = var_num;
+        self
+    }
+
+    pub fn public_inputs(mut self, public_inputs: Vec<u32>) -> Self {
+        self.public_inputs = public_inputs;
+        self
+    }
+
+    pub fn logic_constraints(mut self, logic_constraints: Vec<LogicConstraint>) -> Self {
+        self.logic_constraints = logic_constraints;
+        self
+    }
+
+    pub fn range_constraints(mut self, range_constraints: Vec<RangeConstraint>) -> Self {
+        self.range_constraints = range_constraints;
+        self
+    }
+
+    pub fn sha256_constraints(mut self, sha256_constraints: Vec<Sha256Constraint>) -> Self {
+        self.sha256_constraints = sha256_constraints;
+        self
+    }
+
+    pub fn merkle_membership_constraints(
+        mut self,
+        merkle_membership_constraints: Vec<MerkleMembershipConstraint>,
+    ) -> Self {
+        self.merkle_membership_constraints = merkle_membership_constraints;
+        self
+    }
+
+    pub fn schnorr_constraints(mut self, schnorr_constraints: Vec<SchnorrConstraint>) -> Self {
+        self.schnorr_constraints = schnorr_constraints;
+        self
+    }
+
+    pub fn ecdsa_secp256k1_constraints(
+        mut self,
+        ecdsa_secp256k1_constraints: Vec<EcdsaConstraint>,
+    ) -> Self {
+        self.ecdsa_secp256k1_constraints = ecdsa_secp256k1_constraints;
+        self
+    }
+
+    pub fn blake2s_constraints(mut self, blake2s_constraints: Vec<Blake2sConstraint>) -> Self {
+        self.blake2s_constraints = blake2s_constraints;
+        self
+    }
+
+    pub fn pedersen_constraints(mut self, pedersen_constraints: Vec<PedersenConstraint>) -> Self {
+        self.pedersen_constraints = pedersen_constraints;
+        self
+    }
+
+    pub fn hash_to_field_constraints(
+        mut self,
+        hash_to_field_constraints: Vec<HashToFieldConstraint>,
+    ) -> Self {
+        self.hash_to_field_constraints = hash_to_field_constraints;
+        self
+    }
+
+    pub fn fixed_base_scalar_mul_constraints(
+        mut self,
+        fixed_base_scalar_mul_constraints: Vec<FixedBaseScalarMulConstraint>,
+    ) -> Self {
+        self.fixed_base_scalar_mul_constraints = fixed_base_scalar_mul_constraints;
+        self
+    }
+
+    pub fn constraints(mut self, constraints: Vec<Constraint>) -> Self {
+        self.constraints = constraints;
+        self
+    }
 }
 
 impl ConstraintSystem {
+    pub fn public_inputs_size(&self) -> usize {
+        self.public_inputs.len()
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buffer: Vec<u8> = Vec::new();
 


### PR DESCRIPTION
This builds upon #118 and hides all fields on the ConstraintSystem struct. It then implements an Builder-like pattern on the ConstraintSystem for building them up in tests (note that this is only ever used in tests and in normal use these are constructed via `From<&Circuit>`)

I opted away from an entirely new struct for the builder pattern because we use vecs for everything and they can be defaulted to empty vecs. Marking as a draft so we can decide if this is good enough.