### PR TITLE
chore: remove `Assignments::from_vec`

### DIFF
--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -3,7 +3,6 @@ use crate::composer::StandardComposer;
 use common::acvm::acir::{circuit::Circuit, native_types::Witness};
 use common::acvm::FieldElement;
 use common::acvm::{Language, ProofSystemCompiler};
-use common::barretenberg_structures::Assignments;
 use common::proof;
 use std::collections::BTreeMap;
 
@@ -67,12 +66,8 @@ impl ProofSystemCompiler for Plonk {
 
         // Unlike when proving, we omit any unassigned witnesses.
         // Witness values should be ordered by their index but we skip over any indices without an assignment.
-        let flattened_public_inputs = public_inputs.into_values().collect();
+        let flattened_public_inputs: Vec<FieldElement> = public_inputs.into_values().collect();
 
-        composer.verify_with_vk(
-            proof,
-            Assignments::from_vec(flattened_public_inputs),
-            verification_key,
-        )
+        composer.verify_with_vk(proof, flattened_public_inputs.into(), verification_key)
     }
 }

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -4,7 +4,6 @@ use crate::Barretenberg;
 use common::acvm::acir::{circuit::Circuit, native_types::Witness};
 use common::acvm::FieldElement;
 use common::acvm::{Language, ProofSystemCompiler};
-use common::barretenberg_structures::Assignments;
 use common::proof;
 use std::collections::BTreeMap;
 
@@ -70,12 +69,8 @@ impl ProofSystemCompiler for Plonk {
 
         // Unlike when proving, we omit any unassigned witnesses.
         // Witness values should be ordered by their index but we skip over any indices without an assignment.
-        let flattened_public_inputs = public_inputs.into_values().collect();
+        let flattened_public_inputs: Vec<FieldElement> = public_inputs.into_values().collect();
 
-        composer.verify_with_vk(
-            proof,
-            Assignments::from_vec(flattened_public_inputs),
-            verification_key,
-        )
+        composer.verify_with_vk(proof, flattened_public_inputs.into(), verification_key)
     }
 }

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -29,10 +29,6 @@ impl Assignments {
         buffer
     }
 
-    pub fn from_vec(vec: Vec<Scalar>) -> Assignments {
-        Assignments(vec)
-    }
-
     pub fn push_i32(&mut self, value: i32) {
         self.0.push(Scalar::from(value as i128));
     }

--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -36,7 +36,7 @@ pub fn flatten_witness_map(
 
     // Note: The witnesses are sorted via their witness index
     // witness_values may not have all the witness indexes, e.g for unused witness which are not solved by the solver
-    let witness_assignments = (1..num_witnesses)
+    let witness_assignments: Vec<FieldElement> = (1..num_witnesses)
         .map(|witness_index| {
             // Get the value if it exists. If i does not, then we fill it with the zero value
             witness_values
@@ -45,5 +45,5 @@ pub fn flatten_witness_map(
         })
         .collect();
 
-    Assignments::from_vec(witness_assignments)
+    Assignments::from(witness_assignments)
 }


### PR DESCRIPTION
Cleans up a duplicate method left from https://github.com/noir-lang/aztec_backend/pull/119.

Not marked as breaking as `common` is marked as not for publication so I don't consider it part of our interface.