### PR TITLE
feat!: return boolean rather than `FieldElement` from `verify_signature`

### DIFF
--- a/barretenberg_static_lib/src/acvm_interop/pwg/black_box_functions.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/black_box_functions.rs
@@ -15,12 +15,7 @@ impl BarretenbergShared for Barretenberg {
         Barretenberg::new()
     }
 
-    fn verify_signature(
-        &mut self,
-        pub_key: [u8; 64],
-        sig: [u8; 64],
-        message: &[u8],
-    ) -> FieldElement {
+    fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         self.verify_signature(pub_key, sig, message)
     }
 

--- a/barretenberg_wasm/src/acvm_interop/pwg/black_box_functions.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/black_box_functions.rs
@@ -15,12 +15,7 @@ impl BarretenbergShared for Barretenberg {
         Barretenberg::new()
     }
 
-    fn verify_signature(
-        &mut self,
-        pub_key: [u8; 64],
-        sig: [u8; 64],
-        message: &[u8],
-    ) -> FieldElement {
+    fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         self.verify_signature(pub_key, sig, message)
     }
 


### PR DESCRIPTION
This PR simplifies the `verify_signature` function so that it returns a boolean for whether the signature was valid or not rather than the field element which will be assigned to a witness as a result of this.

This translation is now done in `solve_black_box_func_call`.