### PR TITLE
chore: Add logic constraint test from C++ acir_format tests

### DIFF
--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -330,11 +330,11 @@ impl FixedBaseScalarMulConstraint {
 
 #[derive(Clone, Hash, Debug)]
 pub struct LogicConstraint {
-    a: i32,
-    b: i32,
-    result: i32,
-    num_bits: i32,
-    is_xor_gate: bool,
+    pub a: i32,
+    pub b: i32,
+    pub result: i32,
+    pub num_bits: i32,
+    pub is_xor_gate: bool,
 }
 
 impl LogicConstraint {


### PR DESCRIPTION
This is essentially a copy of the `acir_format` logic constraint test from barretenberg. I am going to be using the logic constraint system in some other tests utilizing recursion so I am adding here separately as to not have PR creep. 