### PR TITLE
chore: Remove mut throughout interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,6 @@ name = "barretenberg_static_lib"
 version = "0.1.0"
 dependencies = [
  "barretenberg-sys",
- "blake2",
  "common",
  "tempfile",
 ]
@@ -276,7 +275,6 @@ dependencies = [
 name = "barretenberg_wasm"
 version = "0.1.0"
 dependencies = [
- "blake2",
  "common",
  "getrandom",
  "pkg-config",

--- a/barretenberg_static_lib/Cargo.toml
+++ b/barretenberg_static_lib/Cargo.toml
@@ -14,5 +14,4 @@ common = { path = "../common" }
 barretenberg-sys = "0.1.1"
 
 [dev-dependencies]
-blake2 = "0.9.1"
 tempfile = "*"

--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -48,7 +48,7 @@ impl ProofSystemCompiler for Plonk {
         witness_values: BTreeMap<Witness, FieldElement>,
         proving_key: &[u8],
     ) -> Vec<u8> {
-        let mut composer = StandardComposer::new(circuit.into());
+        let composer = StandardComposer::new(circuit.into());
 
         let assignments = proof::flatten_witness_map(circuit, witness_values);
 
@@ -62,7 +62,7 @@ impl ProofSystemCompiler for Plonk {
         circuit: &Circuit,
         verification_key: &[u8],
     ) -> bool {
-        let mut composer = StandardComposer::new(circuit.into());
+        let composer = StandardComposer::new(circuit.into());
 
         // Unlike when proving, we omit any unassigned witnesses.
         // Witness values should be ordered by their index but we skip over any indices without an assignment.

--- a/barretenberg_static_lib/src/acvm_interop/pwg/black_box_functions.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/black_box_functions.rs
@@ -15,15 +15,15 @@ impl BarretenbergShared for Barretenberg {
         Barretenberg::new()
     }
 
-    fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
+    fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         self.verify_signature(pub_key, sig, message)
     }
 
-    fn fixed_base(&mut self, input: &FieldElement) -> (FieldElement, FieldElement) {
+    fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
         self.fixed_base(input)
     }
 
-    fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
+    fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
         self.encrypt(inputs)
     }
 }

--- a/barretenberg_static_lib/src/acvm_interop/pwg/merkle.rs
+++ b/barretenberg_static_lib/src/acvm_interop/pwg/merkle.rs
@@ -5,7 +5,7 @@ use common::acvm::FieldElement;
 use common::merkle::PathHasher;
 
 impl PathHasher for Barretenberg {
-    fn hash(&mut self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    fn hash(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
         self.compress_native(left, right)
     }
 
@@ -17,14 +17,14 @@ impl PathHasher for Barretenberg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::merkle::{MerkleTree, MessageHasher};
+    use common::merkle::{Blake2sHasher, MerkleTree, MessageHasher};
 
     #[test]
     fn basic_interop_initial_root() {
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
         // Test that the initial root is computed correctly
-        let tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
         // Copied from barretenberg by copying the stdout from MemoryTree
         let expected_hex = "04ccfbbb859b8605546e03dcaf41393476642859ff7f99446c054b841f0e05c8";
         assert_eq!(tree.root().to_hex(), expected_hex)
@@ -34,7 +34,7 @@ mod tests {
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
         // Test that the hashpath is correct
-        let tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
         let path = tree.get_hash_path(0);
 
@@ -64,7 +64,7 @@ mod tests {
         // Test that computing the HashPath is correct
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
-        let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
         tree.update_message(0, &[0; 64]);
         tree.update_message(1, &[1; 64]);
@@ -159,9 +159,9 @@ mod tests {
 
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
-        let mut msg_hasher: blake2::Blake2s = MessageHasher::new();
+        let msg_hasher: Blake2sHasher = MessageHasher::new();
 
-        let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
         for test_vector in tests {
             let index = FieldElement::try_from_str(test_vector.index).unwrap();
@@ -205,9 +205,9 @@ mod tests {
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
 
-        let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
-        let mut barretenberg = Barretenberg::new();
+        let barretenberg = Barretenberg::new();
         let pubkey_x = FieldElement::from_hex(
             "0x0bff8247aa94b08d1c680d7a3e10831bd8c8cf2ea2c756b0d1d89acdcad877ad",
         )

--- a/barretenberg_static_lib/src/blake2s.rs
+++ b/barretenberg_static_lib/src/blake2s.rs
@@ -4,7 +4,7 @@ use super::Barretenberg;
 
 impl Barretenberg {
     /// Hashes to a bn254 scalar field element using blake2s
-    pub fn hash_to_field(&mut self, input: &[u8]) -> FieldElement {
+    pub fn hash_to_field(&self, input: &[u8]) -> FieldElement {
         let result_prt = barretenberg_sys::blake2s::hash_to_field(input);
 
         FieldElement::from_be_bytes_reduce(&result_prt)
@@ -35,7 +35,7 @@ fn basic_interop() {
         },
     ];
 
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
     for test in tests {
         let expected = FieldElement::from_hex(test.expected_hex).unwrap();
         let got = barretenberg.hash_to_field(&test.input);

--- a/barretenberg_static_lib/src/composer.rs
+++ b/barretenberg_static_lib/src/composer.rs
@@ -101,11 +101,7 @@ impl StandardComposer {
         result.to_vec()
     }
 
-    pub fn create_proof_with_pk(
-        &mut self,
-        witness: WitnessAssignments,
-        proving_key: &[u8],
-    ) -> Vec<u8> {
+    pub fn create_proof_with_pk(&self, witness: WitnessAssignments, proving_key: &[u8]) -> Vec<u8> {
         let cs_buf = self.constraint_system.to_bytes();
         let mut proof_addr: *mut u8 = std::ptr::null_mut();
         let p_proof = &mut proof_addr as *mut *mut u8;
@@ -137,7 +133,7 @@ impl StandardComposer {
     }
 
     pub fn verify_with_vk(
-        &mut self,
+        &self,
         // XXX: Important: This assumes that the proof does not have the public inputs pre-pended to it
         // This is not the case, if you take the proof directly from Barretenberg
         proof: &[u8],
@@ -573,7 +569,7 @@ mod test {
         constraint_system: ConstraintSystem,
         test_cases: Vec<WitnessResult>,
     ) {
-        let mut sc = StandardComposer::new(constraint_system);
+        let sc = StandardComposer::new(constraint_system);
 
         let proving_key = sc.compute_proving_key();
         let verification_key = sc.compute_verification_key(&proving_key);

--- a/barretenberg_static_lib/src/pedersen.rs
+++ b/barretenberg_static_lib/src/pedersen.rs
@@ -4,7 +4,7 @@ use super::field_to_array;
 use super::Barretenberg;
 
 impl Barretenberg {
-    pub fn compress_native(&mut self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    pub fn compress_native(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
         let result_bytes = barretenberg_sys::pedersen::compress_native(
             left.to_be_bytes().as_slice().try_into().unwrap(),
             right.to_be_bytes().as_slice().try_into().unwrap(),
@@ -12,7 +12,7 @@ impl Barretenberg {
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 
-    pub fn compress_many(&mut self, inputs: Vec<FieldElement>) -> FieldElement {
+    pub fn compress_many(&self, inputs: Vec<FieldElement>) -> FieldElement {
         let mut inputs_buf = Vec::new();
         for f in inputs {
             inputs_buf.push(field_to_array(&f));
@@ -21,7 +21,7 @@ impl Barretenberg {
         FieldElement::from_be_bytes_reduce(&result)
     }
 
-    pub fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
+    pub fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
         let mut inputs_buf = Vec::new();
         for f in inputs {
             inputs_buf.push(field_to_array(&f));
@@ -62,7 +62,7 @@ fn basic_interop() {
         },
     ];
 
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
     for test in tests {
         let expected = FieldElement::from_hex(test.expected_hex).unwrap();
 
@@ -75,7 +75,7 @@ fn basic_interop() {
 
 #[test]
 fn pedersen_hash_to_point() {
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
     let (x, y) = barretenberg.encrypt(vec![FieldElement::zero(), FieldElement::one()]);
     let expected_x = FieldElement::from_hex(
         "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",

--- a/barretenberg_static_lib/src/scalar_mul.rs
+++ b/barretenberg_static_lib/src/scalar_mul.rs
@@ -4,7 +4,7 @@ use super::field_to_array;
 use super::Barretenberg;
 
 impl Barretenberg {
-    pub fn fixed_base(&mut self, input: &FieldElement) -> (FieldElement, FieldElement) {
+    pub fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
         let result_bytes = barretenberg_sys::schnorr::construct_public_key(&field_to_array(input));
         let (pubkey_x_bytes, pubkey_y_bytes) = result_bytes.split_at(32);
         let pubkey_x = FieldElement::from_be_bytes_reduce(pubkey_x_bytes);
@@ -18,7 +18,7 @@ mod test {
     use super::*;
     #[test]
     fn smoke_test() {
-        let mut barretenberg = Barretenberg::new();
+        let barretenberg = Barretenberg::new();
         let input = FieldElement::one();
 
         let res = barretenberg.fixed_base(&input);

--- a/barretenberg_static_lib/src/schnorr.rs
+++ b/barretenberg_static_lib/src/schnorr.rs
@@ -3,17 +3,17 @@ use std::convert::TryInto;
 use super::Barretenberg;
 
 impl Barretenberg {
-    pub fn construct_signature(&mut self, message: &[u8], private_key: [u8; 32]) -> [u8; 64] {
+    pub fn construct_signature(&self, message: &[u8], private_key: [u8; 32]) -> [u8; 64] {
         let (s, e) = barretenberg_sys::schnorr::construct_signature(message, private_key);
         let sig_bytes: [u8; 64] = [s, e].concat().try_into().unwrap();
         sig_bytes
     }
 
-    pub fn construct_public_key(&mut self, private_key: [u8; 32]) -> [u8; 64] {
+    pub fn construct_public_key(&self, private_key: [u8; 32]) -> [u8; 64] {
         barretenberg_sys::schnorr::construct_public_key(&private_key)
     }
 
-    pub fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
+    pub fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         barretenberg_sys::schnorr::verify_signature(
             pub_key,
             sig[0..32].try_into().unwrap(),
@@ -28,7 +28,7 @@ impl Barretenberg {
 
 #[test]
 fn basic_interop() {
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
 
     // First case should pass, standard procedure for Schnorr
     let private_key = [2; 32];

--- a/barretenberg_wasm/Cargo.toml
+++ b/barretenberg_wasm/Cargo.toml
@@ -18,7 +18,6 @@ getrandom = "0.2"
 pkg-config = "0.3"
 
 [dev-dependencies]
-blake2 = "0.9.1"
 tempfile = "*"
 
 [features]

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -13,9 +13,9 @@ impl ProofSystemCompiler for Plonk {
     }
 
     fn get_exact_circuit_size(&self, circuit: &Circuit) -> u32 {
-        let mut barretenberg = Barretenberg::new();
+        let barretenberg = Barretenberg::new();
 
-        StandardComposer::get_exact_circuit_size(&mut barretenberg, &circuit.into())
+        StandardComposer::get_exact_circuit_size(&barretenberg, &circuit.into())
     }
 
     fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
@@ -37,7 +37,7 @@ impl ProofSystemCompiler for Plonk {
     }
 
     fn preprocess(&self, circuit: &Circuit) -> (Vec<u8>, Vec<u8>) {
-        let mut composer = StandardComposer::new(circuit.into());
+        let composer = StandardComposer::new(circuit.into());
 
         let proving_key = composer.compute_proving_key();
         let verification_key = composer.compute_verification_key(&proving_key);
@@ -51,7 +51,7 @@ impl ProofSystemCompiler for Plonk {
         witness_values: BTreeMap<Witness, FieldElement>,
         proving_key: &[u8],
     ) -> Vec<u8> {
-        let mut composer = StandardComposer::new(circuit.into());
+        let composer = StandardComposer::new(circuit.into());
 
         let assignments = proof::flatten_witness_map(circuit, witness_values);
 
@@ -65,7 +65,7 @@ impl ProofSystemCompiler for Plonk {
         circuit: &Circuit,
         verification_key: &[u8],
     ) -> bool {
-        let mut composer = StandardComposer::new(circuit.into());
+        let composer = StandardComposer::new(circuit.into());
 
         // Unlike when proving, we omit any unassigned witnesses.
         // Witness values should be ordered by their index but we skip over any indices without an assignment.

--- a/barretenberg_wasm/src/acvm_interop/pwg/black_box_functions.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/black_box_functions.rs
@@ -15,15 +15,15 @@ impl BarretenbergShared for Barretenberg {
         Barretenberg::new()
     }
 
-    fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
+    fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         self.verify_signature(pub_key, sig, message)
     }
 
-    fn fixed_base(&mut self, input: &FieldElement) -> (FieldElement, FieldElement) {
+    fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
         self.fixed_base(input)
     }
 
-    fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
+    fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
         self.encrypt(inputs)
     }
 }

--- a/barretenberg_wasm/src/acvm_interop/pwg/merkle.rs
+++ b/barretenberg_wasm/src/acvm_interop/pwg/merkle.rs
@@ -5,7 +5,7 @@ use common::acvm::FieldElement;
 use common::merkle::PathHasher;
 
 impl PathHasher for Barretenberg {
-    fn hash(&mut self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    fn hash(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
         self.compress_native(left, right)
     }
 
@@ -16,14 +16,14 @@ impl PathHasher for Barretenberg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::merkle::{MerkleTree, MessageHasher};
+    use common::merkle::{Blake2sHasher, MerkleTree, MessageHasher};
 
     #[test]
     fn basic_interop_initial_root() {
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
         // Test that the initial root is computed correctly
-        let tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
         // Copied from barretenberg by copying the stdout from MemoryTree
         let expected_hex = "04ccfbbb859b8605546e03dcaf41393476642859ff7f99446c054b841f0e05c8";
         assert_eq!(tree.root().to_hex(), expected_hex)
@@ -33,7 +33,7 @@ mod tests {
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
         // Test that the hashpath is correct
-        let tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
         let path = tree.get_hash_path(0);
 
@@ -63,7 +63,7 @@ mod tests {
         // Test that computing the HashPath is correct
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
-        let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
         tree.update_message(0, &[0; 64]);
         tree.update_message(1, &[1; 64]);
@@ -158,9 +158,9 @@ mod tests {
 
         use tempfile::tempdir;
         let temp_dir = tempdir().unwrap();
-        let mut msg_hasher: blake2::Blake2s = MessageHasher::new();
+        let msg_hasher: Blake2sHasher = MessageHasher::new();
 
-        let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
+        let tree: MerkleTree<Blake2sHasher, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
         for test_vector in tests {
             let index = FieldElement::try_from_str(test_vector.index).unwrap();

--- a/barretenberg_wasm/src/acvm_interop/smart_contract.rs
+++ b/barretenberg_wasm/src/acvm_interop/smart_contract.rs
@@ -10,7 +10,7 @@ use super::Plonk;
 impl SmartContract for Plonk {
     fn eth_contract_from_vk(&self, verification_key: &[u8]) -> String {
         // TODO: Don't create an entire new wasm instance for one function call
-        let mut barretenberg = Barretenberg::new();
+        let barretenberg = Barretenberg::new();
         let g2 = G2::new();
 
         let g2_ptr = barretenberg.allocate(&g2.data);
@@ -56,7 +56,7 @@ fn test_smart_contract() {
         .public_inputs(vec![1, 2])
         .constraints(vec![constraint]);
 
-    let mut sc = StandardComposer::new(constraint_system);
+    let sc = StandardComposer::new(constraint_system);
 
     let proving_key = sc.compute_proving_key();
     let verification_key = sc.compute_verification_key(&proving_key);

--- a/barretenberg_wasm/src/blake2s.rs
+++ b/barretenberg_wasm/src/blake2s.rs
@@ -5,7 +5,7 @@ use wasmer::Value;
 impl Barretenberg {
     // TODO : Replace this call with a blake2s call and a field element reduce
     /// Hashes to a bn254 scalar field element using blake2s
-    pub fn hash_to_field(&mut self, input: &[u8]) -> FieldElement {
+    pub fn hash_to_field(&self, input: &[u8]) -> FieldElement {
         let input_ptr = self.allocate(input); // 0..32
 
         let result_ptr = Value::I32(0);
@@ -46,7 +46,7 @@ fn basic_interop() {
         },
     ];
 
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
     for test in tests {
         let expected = FieldElement::from_hex(test.expected_hex).unwrap();
         let got = barretenberg.hash_to_field(&test.input);

--- a/barretenberg_wasm/src/composer.rs
+++ b/barretenberg_wasm/src/composer.rs
@@ -14,14 +14,13 @@ pub struct StandardComposer {
 
 impl StandardComposer {
     pub fn new(constraint_system: ConstraintSystem) -> StandardComposer {
-        let mut barretenberg = Barretenberg::new();
+        let barretenberg = Barretenberg::new();
 
-        let circuit_size =
-            StandardComposer::get_circuit_size(&mut barretenberg, &constraint_system);
+        let circuit_size = StandardComposer::get_circuit_size(&barretenberg, &constraint_system);
 
         let crs = CRS::new(circuit_size as usize);
 
-        let pippenger = Pippenger::new(&crs.g1_data, &mut barretenberg);
+        let pippenger = Pippenger::new(&crs.g1_data, &barretenberg);
 
         StandardComposer {
             barretenberg,
@@ -46,7 +45,7 @@ impl StandardComposer {
     // elements we need from the CRS. So using 2^19 on an error
     // should be an overestimation.
     pub fn get_circuit_size(
-        barretenberg: &mut Barretenberg,
+        barretenberg: &Barretenberg,
         constraint_system: &ConstraintSystem,
     ) -> u32 {
         let cs_buf = constraint_system.to_bytes();
@@ -64,7 +63,7 @@ impl StandardComposer {
     }
 
     pub fn get_exact_circuit_size(
-        barretenberg: &mut Barretenberg,
+        barretenberg: &Barretenberg,
         constraint_system: &ConstraintSystem,
     ) -> u32 {
         let cs_buf = constraint_system.to_bytes();
@@ -81,7 +80,7 @@ impl StandardComposer {
         circuit_size
     }
 
-    pub fn compute_proving_key(&mut self) -> Vec<u8> {
+    pub fn compute_proving_key(&self) -> Vec<u8> {
         let cs_buf = self.constraint_system.to_bytes();
         let cs_ptr = self.barretenberg.allocate(&cs_buf);
 
@@ -102,7 +101,7 @@ impl StandardComposer {
         )
     }
 
-    pub fn compute_verification_key(&mut self, proving_key: &[u8]) -> Vec<u8> {
+    pub fn compute_verification_key(&self, proving_key: &[u8]) -> Vec<u8> {
         let g2_ptr = self.barretenberg.allocate(&self.crs.g2_data);
 
         let pk_ptr = self.barretenberg.allocate(proving_key);
@@ -124,11 +123,7 @@ impl StandardComposer {
         )
     }
 
-    pub fn create_proof_with_pk(
-        &mut self,
-        witness: WitnessAssignments,
-        proving_key: &[u8],
-    ) -> Vec<u8> {
+    pub fn create_proof_with_pk(&self, witness: WitnessAssignments, proving_key: &[u8]) -> Vec<u8> {
         let cs_buf = self.constraint_system.to_bytes();
         let cs_ptr = self.barretenberg.allocate(&cs_buf);
 
@@ -165,7 +160,7 @@ impl StandardComposer {
     }
 
     pub fn verify_with_vk(
-        &mut self,
+        &self,
         // XXX: Important: This assumes that the proof does not have the public inputs pre-pended to it
         // This is not the case, if you take the proof directly from Barretenberg
         proof: &[u8],
@@ -532,7 +527,7 @@ mod test {
         constraint_system: ConstraintSystem,
         test_cases: Vec<WitnessResult>,
     ) {
-        let mut sc = StandardComposer::new(constraint_system);
+        let sc = StandardComposer::new(constraint_system);
 
         let proving_key = sc.compute_proving_key();
         let verification_key = sc.compute_verification_key(&proving_key);

--- a/barretenberg_wasm/src/lib.rs
+++ b/barretenberg_wasm/src/lib.rs
@@ -51,7 +51,7 @@ impl WASMValue {
 
 impl Barretenberg {
     /// Transfer bytes to WASM heap
-    pub fn transfer_to_heap(&mut self, arr: &[u8], offset: usize) {
+    pub fn transfer_to_heap(&self, arr: &[u8], offset: usize) {
         let memory = &self.memory;
 
         #[cfg(feature = "js")]
@@ -102,7 +102,7 @@ impl Barretenberg {
     }
 
     /// Creates a pointer and allocates the bytes that the pointer references to, to the heap
-    pub fn allocate(&mut self, bytes: &[u8]) -> Value {
+    pub fn allocate(&self, bytes: &[u8]) -> Value {
         let ptr = self
             .call("bbmalloc", &Value::I32(bytes.len() as i32))
             .value();
@@ -117,7 +117,7 @@ impl Barretenberg {
     /// Frees a pointer.
     /// Notice we consume the Value, if you clone the value before passing it to free
     /// It most likely is a bug
-    pub fn free(&mut self, pointer: Value) {
+    pub fn free(&self, pointer: Value) {
         self.call("bbfree", &pointer);
     }
 }
@@ -278,7 +278,7 @@ fn env_load_prover_crs(_: i32) -> i32 {
 
 #[test]
 fn smoke() {
-    let mut b = Barretenberg::new();
+    let b = Barretenberg::new();
     let (x, y) = b.encrypt(vec![
         common::acvm::FieldElement::zero(),
         common::acvm::FieldElement::one(),

--- a/barretenberg_wasm/src/pedersen.rs
+++ b/barretenberg_wasm/src/pedersen.rs
@@ -6,7 +6,7 @@ use common::barretenberg_structures::Assignments;
 use super::Barretenberg;
 
 impl Barretenberg {
-    pub fn compress_native(&mut self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    pub fn compress_native(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
         let lhs_ptr = self.allocate(&left.to_be_bytes()); // 0..32
         let rhs_ptr = self.allocate(&right.to_be_bytes()); // 32..64
         let result_ptr = Value::I32(64); // 64..96
@@ -18,7 +18,7 @@ impl Barretenberg {
         let result_bytes = self.slice_memory(64, 96);
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
-    pub fn compress_many(&mut self, inputs: Vec<FieldElement>) -> FieldElement {
+    pub fn compress_many(&self, inputs: Vec<FieldElement>) -> FieldElement {
         let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf);
 
@@ -31,7 +31,7 @@ impl Barretenberg {
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 
-    pub fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
+    pub fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
         let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf);
 
@@ -78,7 +78,7 @@ fn basic_interop() {
         },
     ];
 
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
     for test in tests {
         let expected = FieldElement::from_hex(test.expected_hex).unwrap();
 
@@ -91,7 +91,7 @@ fn basic_interop() {
 
 #[test]
 fn pedersen_hash_to_point() {
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
     let (x, y) = barretenberg.encrypt(vec![FieldElement::zero(), FieldElement::one()]);
     let expected_x = FieldElement::from_hex(
         "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",

--- a/barretenberg_wasm/src/pippenger.rs
+++ b/barretenberg_wasm/src/pippenger.rs
@@ -6,7 +6,7 @@ pub struct Pippenger {
 }
 
 impl Pippenger {
-    pub fn new(crs_data: &[u8], barretenberg: &mut Barretenberg) -> Pippenger {
+    pub fn new(crs_data: &[u8], barretenberg: &Barretenberg) -> Pippenger {
         let num_points = Value::I32((crs_data.len() / 64) as i32);
 
         let crs_ptr = barretenberg.allocate(crs_data);

--- a/barretenberg_wasm/src/scalar_mul.rs
+++ b/barretenberg_wasm/src/scalar_mul.rs
@@ -4,7 +4,7 @@ use wasmer::Value;
 use super::Barretenberg;
 
 impl Barretenberg {
-    pub fn fixed_base(&mut self, input: &FieldElement) -> (FieldElement, FieldElement) {
+    pub fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
         let lhs_ptr = self.allocate(&input.to_be_bytes()); // 0..32
         let result_ptr = Value::I32(32);
         self.call_multiple("compute_public_key", vec![&lhs_ptr, &result_ptr]);
@@ -25,7 +25,7 @@ mod test {
     use super::*;
     #[test]
     fn smoke_test() {
-        let mut barretenberg = Barretenberg::new();
+        let barretenberg = Barretenberg::new();
         let input = FieldElement::one();
 
         let res = barretenberg.fixed_base(&input);

--- a/barretenberg_wasm/src/schnorr.rs
+++ b/barretenberg_wasm/src/schnorr.rs
@@ -3,7 +3,7 @@ use wasmer::Value;
 
 use super::Barretenberg;
 impl Barretenberg {
-    pub fn construct_signature(&mut self, message: &[u8], private_key: [u8; 32]) -> [u8; 64] {
+    pub fn construct_signature(&self, message: &[u8], private_key: [u8; 32]) -> [u8; 64] {
         self.transfer_to_heap(&private_key, 64);
         self.transfer_to_heap(message, 96);
         let message_len = Value::I32(message.len() as i32);
@@ -22,7 +22,7 @@ impl Barretenberg {
         sig_bytes.try_into().unwrap()
     }
 
-    pub fn construct_public_key(&mut self, private_key: [u8; 32]) -> [u8; 64] {
+    pub fn construct_public_key(&self, private_key: [u8; 32]) -> [u8; 64] {
         self.transfer_to_heap(&private_key, 0);
 
         self.call_multiple("compute_public_key", vec![&Value::I32(0), &Value::I32(32)]);
@@ -30,7 +30,7 @@ impl Barretenberg {
         self.slice_memory(32, 96).try_into().unwrap()
     }
 
-    pub fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
+    pub fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         self.transfer_to_heap(&pub_key, 0);
         self.transfer_to_heap(&sig[0..32], 64);
         self.transfer_to_heap(&sig[32..64], 96);
@@ -59,7 +59,7 @@ impl Barretenberg {
 
 #[test]
 fn basic_interop() {
-    let mut barretenberg = Barretenberg::new();
+    let barretenberg = Barretenberg::new();
 
     // First case should pass, standard procedure for Schnorr
     let private_key = [2; 32];

--- a/common/src/black_box_functions.rs
+++ b/common/src/black_box_functions.rs
@@ -14,9 +14,9 @@ use crate::merkle::PathHasher;
 // that the PWG needs from Barretenberg
 pub trait BarretenbergShared: PathHasher {
     fn new() -> Self;
-    fn verify_signature(&mut self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool;
-    fn fixed_base(&mut self, input: &FieldElement) -> (FieldElement, FieldElement);
-    fn encrypt(&mut self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement);
+    fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool;
+    fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement);
+    fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement);
 }
 
 pub fn solve_black_box_func_call<B: BarretenbergShared>(
@@ -99,7 +99,7 @@ pub fn solve_black_box_func_call<B: BarretenbergShared>(
                 message.push(msg_i);
             }
 
-            let mut barretenberg = <B as BarretenbergShared>::new();
+            let barretenberg = <B as BarretenbergShared>::new();
 
             let valid_signature = barretenberg.verify_signature(pub_key, signature, &message);
             if !valid_signature {
@@ -121,7 +121,7 @@ pub fn solve_black_box_func_call<B: BarretenbergShared>(
                 .map(|input| witness_to_value(initial_witness, input.witness))
                 .collect();
             let scalars: Vec<_> = scalars?.into_iter().cloned().collect();
-            let mut barretenberg = <B as BarretenbergShared>::new();
+            let barretenberg = <B as BarretenbergShared>::new();
 
             let (res_x, res_y) = barretenberg.encrypt(scalars);
             initial_witness.insert(gadget_call.outputs[0], res_x);
@@ -153,7 +153,7 @@ pub fn solve_black_box_func_call<B: BarretenbergShared>(
         BlackBoxFunc::FixedBaseScalarMul => {
             let scalar = witness_to_value(initial_witness, gadget_call.inputs[0].witness)?;
 
-            let mut barretenberg = <B as BarretenbergShared>::new();
+            let barretenberg = <B as BarretenbergShared>::new();
             let (pub_x, pub_y) = barretenberg.fixed_base(scalar);
 
             initial_witness.insert(gadget_call.outputs[0], pub_x);


### PR DESCRIPTION
While exploring https://github.com/noir-lang/acvm/issues/211, I wanted to see exactly **why** this backend needed things as `&mut self` so I started removing stuff. It seems like the only things that needed to be mutable were Assignments and the Blake2s hasher. These could both be worked-around by using `std::cell::RefCell`, I believe.

This seems to pass all the tests and remove mut on pretty much the entire interface (unless my grepping missed something).