### PR TITLE
chore: cleaner implementation of `black_box_function_supported`

### DIFF
--- a/barretenberg_static_lib/src/acvm_interop/proof_system.rs
+++ b/barretenberg_static_lib/src/acvm_interop/proof_system.rs
@@ -1,6 +1,6 @@
 use super::Plonk;
 use crate::composer::StandardComposer;
-use common::acvm::acir::{circuit::Circuit, native_types::Witness};
+use common::acvm::acir::{circuit::Circuit, native_types::Witness, BlackBoxFunc};
 use common::acvm::FieldElement;
 use common::acvm::{Language, ProofSystemCompiler};
 use common::proof;
@@ -15,21 +15,21 @@ impl ProofSystemCompiler for Plonk {
         StandardComposer::get_exact_circuit_size(&circuit.into())
     }
 
-    fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
+    fn black_box_function_supported(&self, opcode: &BlackBoxFunc) -> bool {
         match opcode {
-            common::acvm::acir::BlackBoxFunc::AES => false,
-            common::acvm::acir::BlackBoxFunc::AND => true,
-            common::acvm::acir::BlackBoxFunc::XOR => true,
-            common::acvm::acir::BlackBoxFunc::RANGE => true,
-            common::acvm::acir::BlackBoxFunc::SHA256 => true,
-            common::acvm::acir::BlackBoxFunc::Blake2s => true,
-            common::acvm::acir::BlackBoxFunc::MerkleMembership => true,
-            common::acvm::acir::BlackBoxFunc::SchnorrVerify => true,
-            common::acvm::acir::BlackBoxFunc::Pedersen => true,
-            common::acvm::acir::BlackBoxFunc::HashToField128Security => true,
-            common::acvm::acir::BlackBoxFunc::EcdsaSecp256k1 => true,
-            common::acvm::acir::BlackBoxFunc::FixedBaseScalarMul => true,
-            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
+            BlackBoxFunc::AND
+            | BlackBoxFunc::XOR
+            | BlackBoxFunc::RANGE
+            | BlackBoxFunc::SHA256
+            | BlackBoxFunc::Blake2s
+            | BlackBoxFunc::MerkleMembership
+            | BlackBoxFunc::SchnorrVerify
+            | BlackBoxFunc::Pedersen
+            | BlackBoxFunc::HashToField128Security
+            | BlackBoxFunc::EcdsaSecp256k1
+            | BlackBoxFunc::FixedBaseScalarMul => true,
+
+            BlackBoxFunc::AES | BlackBoxFunc::Keccak256 => false,
         }
     }
 

--- a/barretenberg_wasm/src/acvm_interop/proof_system.rs
+++ b/barretenberg_wasm/src/acvm_interop/proof_system.rs
@@ -1,7 +1,7 @@
 use super::Plonk;
 use crate::composer::StandardComposer;
 use crate::Barretenberg;
-use common::acvm::acir::{circuit::Circuit, native_types::Witness};
+use common::acvm::acir::{circuit::Circuit, native_types::Witness, BlackBoxFunc};
 use common::acvm::FieldElement;
 use common::acvm::{Language, ProofSystemCompiler};
 use common::proof;
@@ -18,21 +18,21 @@ impl ProofSystemCompiler for Plonk {
         StandardComposer::get_exact_circuit_size(&mut barretenberg, &circuit.into())
     }
 
-    fn black_box_function_supported(&self, opcode: &common::acvm::acir::BlackBoxFunc) -> bool {
+    fn black_box_function_supported(&self, opcode: &BlackBoxFunc) -> bool {
         match opcode {
-            common::acvm::acir::BlackBoxFunc::AES => false,
-            common::acvm::acir::BlackBoxFunc::AND => true,
-            common::acvm::acir::BlackBoxFunc::XOR => true,
-            common::acvm::acir::BlackBoxFunc::RANGE => true,
-            common::acvm::acir::BlackBoxFunc::SHA256 => true,
-            common::acvm::acir::BlackBoxFunc::Blake2s => true,
-            common::acvm::acir::BlackBoxFunc::MerkleMembership => true,
-            common::acvm::acir::BlackBoxFunc::SchnorrVerify => true,
-            common::acvm::acir::BlackBoxFunc::Pedersen => true,
-            common::acvm::acir::BlackBoxFunc::HashToField128Security => true,
-            common::acvm::acir::BlackBoxFunc::EcdsaSecp256k1 => true,
-            common::acvm::acir::BlackBoxFunc::FixedBaseScalarMul => true,
-            common::acvm::acir::BlackBoxFunc::Keccak256 => false,
+            BlackBoxFunc::AND
+            | BlackBoxFunc::XOR
+            | BlackBoxFunc::RANGE
+            | BlackBoxFunc::SHA256
+            | BlackBoxFunc::Blake2s
+            | BlackBoxFunc::MerkleMembership
+            | BlackBoxFunc::SchnorrVerify
+            | BlackBoxFunc::Pedersen
+            | BlackBoxFunc::HashToField128Security
+            | BlackBoxFunc::EcdsaSecp256k1
+            | BlackBoxFunc::FixedBaseScalarMul => true,
+
+            BlackBoxFunc::AES | BlackBoxFunc::Keccak256 => false,
         }
     }
 


### PR DESCRIPTION
This function has been bugging me so I've partitioned and grouped the arms depending on whether we support the BB function or not