### PR TITLE
chore(ci): Cache cargo dependencies between runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/nix-cache
-          key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}
+          key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
 
       # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
       - name: Copy cache into nix store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,15 @@ jobs:
         with:
           name: barretenberg
 
-      - name: Restore Cache
+      - name: Restore nix store cache
+        id: nix-store-cache
         uses: actions/cache@v3
         with:
           path: /tmp/nix-cache
           key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}
 
       - name: Copy cache into nix store
+        if: steps.nix-store-cache.outputs.cache-hit == 'true'
         run: |
           nix copy --from "file:/tmp/nix-cache"
 
@@ -49,5 +51,6 @@ jobs:
           nix flake check -L
 
       - name: Export cache from nix store
+        if: steps.nix-store-cache.outputs.cache-hit != 'true'
         run: |
           nix copy --to "file:/tmp/nix-cache?compression=zstd&parallel-compression=true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,20 @@ jobs:
         with:
           name: barretenberg
 
+      - name: Restore Cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/nix-cache
+          key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}
+
+      - name: Copy cache into nix store
+        run: |
+          nix copy --from "file:/tmp/nix-cache"
+
       - name: Run `nix flake check`
         run: |
           nix flake check -L
+
+      - name: Export cache from nix store
+        run: |
+          nix copy --to "file:/tmp/nix-cache?compression=zstd&parallel-compression=true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,10 @@ jobs:
           path: /tmp/nix-cache
           key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}
 
+      # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
       - name: Copy cache into nix store
         if: steps.nix-store-cache.outputs.cache-hit == 'true'
+        # We don't check the signature because we're the one that created the cache
         run: |
           for narinfo in /tmp/nix-cache/*.narinfo; do
             path=$(head -n 1 "$narinfo" | awk '{print $2}')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Copy cache into nix store
         if: steps.nix-store-cache.outputs.cache-hit == 'true'
         run: |
-          nix copy --from "file:/tmp/nix-cache"
+          for narinfo in /tmp/nix-cache/*.narinfo; do
+            path=$(head -n 1 "$narinfo" | awk '{print $2}')
+            nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
+          done
 
       - name: Run `nix flake check`
         run: |
@@ -53,4 +56,4 @@ jobs:
       - name: Export cache from nix store
         if: steps.nix-store-cache.outputs.cache-hit != 'true'
         run: |
-          nix copy --to "file:/tmp/nix-cache?compression=zstd&parallel-compression=true"
+          nix copy --to "file:///tmp/nix-cache?compression=zstd&parallel-compression=true" .#cargo-artifacts

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,3 +15,5 @@ pub use acvm;
 
 /// Embed the Solidity verifier file
 pub const ULTRA_VERIFIER_CONTRACT: &str = include_str!("contract.sol");
+
+// Some rust change?

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,5 +15,3 @@ pub use acvm;
 
 /// Embed the Solidity verifier file
 pub const ULTRA_VERIFIER_CONTRACT: &str = include_str!("contract.sol");
-
-// Some rust change?

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,8 @@
       };
 
       packages.default = acvm-backend-barretenberg;
+
+      # We expose the `cargo-artifacts` derivation so we can cache our cargo dependencies in CI
       packages.cargo-artifacts = cargoArtifacts;
 
       # Setup the environment to match the stdenv from `nix build` & `nix flake check`, and

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,7 @@
       };
 
       packages.default = acvm-backend-barretenberg;
+      packages.cargo-artifacts = cargoArtifacts;
 
       # Setup the environment to match the stdenv from `nix build` & `nix flake check`, and
       # combine it with the environment settings, the inputs from our checks derivations,


### PR DESCRIPTION
This caches the "cargoArtifacts" derivation from Nix via GitHub Actions Cache. That includes all cargo dependencies as produced by `craneLib.buildDepsOnly`. We then import the deps into Nix if the cache exists.

This reduced the CI run on ubuntu down to 7 minutes, roughly 5-6 of it being the actual test run.