### PR TITLE
chore: Use pollster as async executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "barretenberg-sys",
  "blake2",
  "common",
+ "pollster",
  "tempfile",
 ]
 
@@ -476,9 +477,9 @@ dependencies = [
  "dirs 3.0.2",
  "futures-util",
  "indicatif",
+ "pollster",
  "reqwest",
  "sled",
- "tokio",
 ]
 
 [[package]]
@@ -1647,6 +1648,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "pollster"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "barretenberg-sys",
  "blake2",
  "common",
- "pollster",
  "tempfile",
 ]
 

--- a/barretenberg_static_lib/Cargo.toml
+++ b/barretenberg_static_lib/Cargo.toml
@@ -16,4 +16,3 @@ barretenberg-sys = "0.1.2"
 [dev-dependencies]
 blake2 = "0.9.1"
 tempfile = "*"
-pollster = "0.3.0"

--- a/barretenberg_static_lib/Cargo.toml
+++ b/barretenberg_static_lib/Cargo.toml
@@ -16,3 +16,4 @@ barretenberg-sys = "0.1.2"
 [dev-dependencies]
 blake2 = "0.9.1"
 tempfile = "*"
+pollster = "0.3.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,10 +16,10 @@ sled = "0.34.6"
 blake2 = "0.9.1"
 dirs = { version = "3.0", optional = true }
 reqwest = { version = "0.11.16", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
-tokio = { version = "1.0", optional = true }
 futures-util = { version = "0.3.14", optional = true }
 indicatif = { version = "0.17.3", optional = true }
+pollster = "0.3.0"
 
 [features]
 default = ["std"]
-std = ["dep:reqwest", "dep:tokio", "dep:futures-util", "dep:dirs", "dep:indicatif"]
+std = ["dep:reqwest", "dep:futures-util", "dep:dirs", "dep:indicatif"]


### PR DESCRIPTION
This drops the direct `tokio` dependency (it still exists inside reqwest) and uses [pollster](https://crates.io/crates/pollster) for `block_on`. Their package readme has a good "why" for itself.

I was trying to understand if we can `block_on` when compiling to JS with wasm-bindgen and found this comment: https://github.com/async-rs/async-std/issues/913#issuecomment-1296282060 which recommended pollster. I tried it in a demo wasm-pack project I have an it seems to block on an async function, so I think we can layer JS promises and it should work 🤞 

