### PR TITLE
chore: remove outdated comment

### DIFF
--- a/common/src/black_box_functions.rs
+++ b/common/src/black_box_functions.rs
@@ -128,8 +128,6 @@ pub fn solve_black_box_func_call<B: BarretenbergShared>(
             initial_witness.insert(gadget_call.outputs[1], res_y);
         }
         BlackBoxFunc::HashToField128Security => {
-            // Deal with Blake2s -- XXX: It's not possible for pwg to know that it is Blake2s
-            // We need to get this method from the backend
             let mut hasher = <Blake2s as blake2::Digest>::new();
 
             // 0. For each input in the vector of inputs, check if we have their witness assignments (Can do this outside of match, since they all have inputs)


### PR DESCRIPTION
This comment was from a time when each backend would define how it would do particular operations. Now, we are of the opinion that this should be standardized by ACIR