### PR TITLE
chore: miscellaneous refactoring of `barretenberg_structures`

### DIFF
--- a/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
+++ b/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
@@ -71,7 +71,7 @@ fn test_smart_contract() {
     use crate::composer::Composer;
     use crate::Barretenberg;
     use common::acvm::FieldElement;
-    use common::barretenberg_structures::ConstraintSystem;
+    use common::barretenberg_structures::{Constraint, ConstraintSystem};
 
     let constraint = Constraint {
         a: 1,

--- a/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
+++ b/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
@@ -70,8 +70,8 @@ impl SmartContract for Barretenberg {
 fn test_smart_contract() {
     use crate::composer::Composer;
     use crate::Barretenberg;
-    use common::barretenberg_structures::*;
     use common::acvm::FieldElement;
+    use common::barretenberg_structures::ConstraintSystem;
 
     let constraint = Constraint {
         a: 1,

--- a/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
+++ b/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
@@ -76,11 +76,11 @@ fn test_smart_contract() {
         a: 1,
         b: 2,
         c: 3,
-        qm: Scalar::zero(),
-        ql: Scalar::one(),
-        qr: Scalar::one(),
-        qo: -Scalar::one(),
-        qc: Scalar::zero(),
+        qm: FieldElement::zero(),
+        ql: FieldElement::one(),
+        qr: FieldElement::one(),
+        qo: -FieldElement::one(),
+        qc: FieldElement::zero(),
     };
 
     let constraint_system = ConstraintSystem::new()

--- a/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
+++ b/acvm_backend_barretenberg/src/acvm_interop/smart_contract.rs
@@ -71,6 +71,7 @@ fn test_smart_contract() {
     use crate::composer::Composer;
     use crate::Barretenberg;
     use common::barretenberg_structures::*;
+    use common::acvm::FieldElement;
 
     let constraint = Constraint {
         a: 1,

--- a/acvm_backend_barretenberg/src/composer.rs
+++ b/acvm_backend_barretenberg/src/composer.rs
@@ -425,7 +425,7 @@ fn pow2ceil(v: u32) -> u32 {
 mod test {
 
     use super::*;
-    use common::barretenberg_structures::{Constraint, PedersenConstraint, Scalar};
+    use common::barretenberg_structures::{Constraint, FieldElement, PedersenConstraint};
 
     #[test]
     fn test_no_constraints_no_pub_inputs() {
@@ -447,11 +447,11 @@ mod test {
             a: 1,
             b: 2,
             c: 3,
-            qm: Scalar::zero(),
-            ql: Scalar::one(),
-            qr: Scalar::one(),
-            qo: -Scalar::one(),
-            qc: Scalar::zero(),
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::one(),
+            qo: -FieldElement::one(),
+            qc: FieldElement::zero(),
         };
 
         let constraint_system = ConstraintSystem::new()
@@ -464,7 +464,12 @@ mod test {
             result: true,
         };
         let case_2 = WitnessResult {
-            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::zero()].into(),
+            witness: vec![
+                FieldElement::zero(),
+                FieldElement::zero(),
+                FieldElement::zero(),
+            ]
+            .into(),
             public_inputs: Assignments::default(),
             result: true,
         };
@@ -474,12 +479,17 @@ mod test {
             result: true,
         };
         let case_4 = WitnessResult {
-            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::one()].into(),
+            witness: vec![
+                FieldElement::zero(),
+                FieldElement::zero(),
+                FieldElement::one(),
+            ]
+            .into(),
             public_inputs: Assignments::default(),
             result: false,
         };
         let case_5 = WitnessResult {
-            witness: vec![Scalar::one(), 2_i128.into(), 6_i128.into()].into(),
+            witness: vec![FieldElement::one(), 2_i128.into(), 6_i128.into()].into(),
             public_inputs: Assignments::default(),
             result: false,
         };
@@ -493,11 +503,11 @@ mod test {
             a: 1,
             b: 2,
             c: 3,
-            qm: Scalar::zero(),
-            ql: Scalar::one(),
-            qr: Scalar::one(),
-            qo: -Scalar::one(),
-            qc: Scalar::zero(),
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::one(),
+            qo: -FieldElement::one(),
+            qc: FieldElement::zero(),
         };
 
         let constraint_system = ConstraintSystem::new()
@@ -514,33 +524,43 @@ mod test {
             result: false,
         };
         let case_2 = WitnessResult {
-            witness: vec![Scalar::zero(), Scalar::zero(), Scalar::zero()].into(),
-            public_inputs: vec![Scalar::zero(), Scalar::zero()].into(),
+            witness: vec![
+                FieldElement::zero(),
+                FieldElement::zero(),
+                FieldElement::zero(),
+            ]
+            .into(),
+            public_inputs: vec![FieldElement::zero(), FieldElement::zero()].into(),
             result: true,
         };
 
         let case_3 = WitnessResult {
-            witness: vec![Scalar::one(), 2_i128.into(), 6_i128.into()].into(),
-            public_inputs: vec![Scalar::one(), 3_i128.into()].into(),
+            witness: vec![FieldElement::one(), 2_i128.into(), 6_i128.into()].into(),
+            public_inputs: vec![FieldElement::one(), 3_i128.into()].into(),
             result: false,
         };
 
         // Not enough public inputs
         let _case_4 = WitnessResult {
-            witness: vec![Scalar::one(), Scalar::from(2_i128), Scalar::from(6_i128)].into(),
-            public_inputs: vec![Scalar::one()].into(),
+            witness: vec![
+                FieldElement::one(),
+                FieldElement::from(2_i128),
+                FieldElement::from(6_i128),
+            ]
+            .into(),
+            public_inputs: vec![FieldElement::one()].into(),
             result: false,
         };
 
         let case_5 = WitnessResult {
-            witness: vec![Scalar::one(), 2_i128.into(), 3_i128.into()].into(),
-            public_inputs: vec![Scalar::one(), 2_i128.into()].into(),
+            witness: vec![FieldElement::one(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![FieldElement::one(), 2_i128.into()].into(),
             result: true,
         };
 
         let case_6 = WitnessResult {
-            witness: vec![Scalar::one(), 2_i128.into(), 3_i128.into()].into(),
-            public_inputs: vec![Scalar::one(), 3_i128.into()].into(),
+            witness: vec![FieldElement::one(), 2_i128.into(), 3_i128.into()].into(),
+            public_inputs: vec![FieldElement::one(), 3_i128.into()].into(),
             result: false,
         };
         let test_cases = vec![
@@ -556,21 +576,21 @@ mod test {
             a: 1,
             b: 2,
             c: 3,
-            qm: Scalar::zero(),
-            ql: Scalar::one(),
-            qr: Scalar::one(),
-            qo: -Scalar::one(),
-            qc: Scalar::zero(),
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::one(),
+            qo: -FieldElement::one(),
+            qc: FieldElement::zero(),
         };
         let constraint2 = Constraint {
             a: 2,
             b: 3,
             c: 4,
-            qm: Scalar::one(),
-            ql: Scalar::zero(),
-            qr: Scalar::zero(),
-            qo: -Scalar::one(),
-            qc: Scalar::one(),
+            qm: FieldElement::one(),
+            ql: FieldElement::zero(),
+            qr: FieldElement::zero(),
+            qo: -FieldElement::one(),
+            qc: FieldElement::one(),
         };
 
         let constraint_system = ConstraintSystem::new()
@@ -580,12 +600,12 @@ mod test {
 
         let case_1 = WitnessResult {
             witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 3_i128.into()].into(),
-            public_inputs: vec![Scalar::one()].into(),
+            public_inputs: vec![FieldElement::one()].into(),
             result: true,
         };
         let case_2 = WitnessResult {
             witness: vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 13_i128.into()].into(),
-            public_inputs: vec![Scalar::one()].into(),
+            public_inputs: vec![FieldElement::one()].into(),
             result: false,
         };
 
@@ -612,11 +632,11 @@ mod test {
             a: result_index,
             b: result_index,
             c: result_index,
-            qm: Scalar::zero(),
-            ql: Scalar::zero(),
-            qr: Scalar::zero(),
-            qo: Scalar::one(),
-            qc: -Scalar::one(),
+            qm: FieldElement::zero(),
+            ql: FieldElement::zero(),
+            qr: FieldElement::zero(),
+            qo: FieldElement::one(),
+            qc: -FieldElement::one(),
         };
 
         let constraint_system = ConstraintSystem::new()
@@ -624,12 +644,14 @@ mod test {
             .schnorr_constraints(vec![constraint])
             .constraints(vec![arith_constraint]);
 
-        let pub_x =
-            Scalar::from_hex("0x17cbd3ed3151ccfd170efe1d54280a6a4822640bf5c369908ad74ea21518a9c5")
-                .unwrap();
-        let pub_y =
-            Scalar::from_hex("0x0e0456e3795c1a31f20035b741cd6158929eeccd320d299cfcac962865a6bc74")
-                .unwrap();
+        let pub_x = FieldElement::from_hex(
+            "0x17cbd3ed3151ccfd170efe1d54280a6a4822640bf5c369908ad74ea21518a9c5",
+        )
+        .unwrap();
+        let pub_y = FieldElement::from_hex(
+            "0x0e0456e3795c1a31f20035b741cd6158929eeccd320d299cfcac962865a6bc74",
+        )
+        .unwrap();
 
         let sig: [i128; 64] = [
             5, 202, 31, 146, 81, 242, 246, 69, 43, 107, 249, 153, 198, 44, 14, 111, 191, 121, 137,
@@ -637,11 +659,11 @@ mod test {
             192, 53, 138, 205, 69, 33, 236, 163, 83, 194, 84, 137, 184, 221, 176, 121, 179, 27, 63,
             70, 54, 16, 176, 250, 39, 239,
         ];
-        let mut sig_as_scalars = [Scalar::zero(); 64];
+        let mut sig_as_FieldElements = [FieldElement::zero(); 64];
         for i in 0..64 {
-            sig_as_scalars[i] = sig[i].into()
+            sig_as_FieldElements[i] = sig[i].into()
         }
-        let message: Vec<Scalar> = vec![
+        let message: Vec<FieldElement> = vec![
             0_i128.into(),
             1_i128.into(),
             2_i128.into(),
@@ -657,8 +679,8 @@ mod test {
         witness_values.extend(message);
         witness_values.push(pub_x);
         witness_values.push(pub_y);
-        witness_values.extend(sig_as_scalars);
-        witness_values.push(Scalar::zero());
+        witness_values.extend(sig_as_FieldElements);
+        witness_values.push(FieldElement::zero());
 
         let case_1 = WitnessResult {
             witness: witness_values.into(),
@@ -681,11 +703,11 @@ mod test {
             a: 3,
             b: 3,
             c: 3,
-            qm: Scalar::zero(),
-            ql: Scalar::one(),
-            qr: Scalar::zero(),
-            qo: Scalar::zero(),
-            qc: -Scalar::from_hex(
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::zero(),
+            qo: FieldElement::zero(),
+            qc: -FieldElement::from_hex(
                 "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",
             )
             .unwrap(),
@@ -694,11 +716,11 @@ mod test {
             a: 4,
             b: 4,
             c: 4,
-            qm: Scalar::zero(),
-            ql: Scalar::one(),
-            qr: Scalar::zero(),
-            qo: Scalar::zero(),
-            qc: -Scalar::from_hex(
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::zero(),
+            qo: FieldElement::zero(),
+            qc: -FieldElement::from_hex(
                 "0x0ecf9d98be4597a88c46a7e0fa8836b57a7dcb41ee30f8d8787b11cc259c83fa",
             )
             .unwrap(),
@@ -709,8 +731,8 @@ mod test {
             .pedersen_constraints(vec![constraint])
             .constraints(vec![x_constraint, y_constraint]);
 
-        let scalar_0 = Scalar::from_hex("0x00").unwrap();
-        let scalar_1 = Scalar::from_hex("0x01").unwrap();
+        let scalar_0 = FieldElement::from_hex("0x00").unwrap();
+        let scalar_1 = FieldElement::from_hex("0x01").unwrap();
         let witness_values = vec![scalar_0, scalar_1];
 
         let case_1 = WitnessResult {
@@ -747,41 +769,41 @@ mod test {
             a: 3,
             b: 4,
             c: 0,
-            qm: Scalar::zero(),
-            ql: Scalar::one(),
-            qr: -Scalar::one(),
-            qo: Scalar::zero(),
-            qc: -Scalar::from_hex("0x0a").unwrap(),
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: -FieldElement::one(),
+            qo: FieldElement::zero(),
+            qc: -FieldElement::from_hex("0x0a").unwrap(),
         };
         let expr_b = Constraint {
             a: 4,
             b: 5,
             c: 6,
-            qm: Scalar::one(),
-            ql: Scalar::zero(),
-            qr: Scalar::zero(),
-            qo: -Scalar::one(),
-            qc: Scalar::zero(),
+            qm: FieldElement::one(),
+            ql: FieldElement::zero(),
+            qr: FieldElement::zero(),
+            qo: -FieldElement::one(),
+            qc: FieldElement::zero(),
         };
         let expr_c = Constraint {
             a: 4,
             b: 6,
             c: 4,
-            qm: Scalar::one(),
-            ql: Scalar::zero(),
-            qr: Scalar::zero(),
-            qo: -Scalar::one(),
-            qc: Scalar::zero(),
+            qm: FieldElement::one(),
+            ql: FieldElement::zero(),
+            qr: FieldElement::zero(),
+            qo: -FieldElement::one(),
+            qc: FieldElement::zero(),
         };
         let expr_d = Constraint {
             a: 6,
             b: 0,
             c: 0,
-            qm: Scalar::zero(),
-            ql: -Scalar::one(),
-            qr: Scalar::zero(),
-            qo: Scalar::zero(),
-            qc: Scalar::one(),
+            qm: FieldElement::zero(),
+            ql: -FieldElement::one(),
+            qr: FieldElement::zero(),
+            qo: FieldElement::zero(),
+            qc: FieldElement::one(),
         };
 
         let constraint_system = ConstraintSystem::new()
@@ -791,9 +813,9 @@ mod test {
             .logic_constraints(vec![logic_constraint])
             .constraints(vec![expr_a, expr_b, expr_c, expr_d]);
 
-        let scalar_5 = Scalar::from_hex("0x05").unwrap();
-        let scalar_10 = Scalar::from_hex("0x0a").unwrap();
-        let scalar_15 = Scalar::from_hex("0x0f").unwrap();
+        let scalar_5 = FieldElement::from_hex("0x05").unwrap();
+        let scalar_10 = FieldElement::from_hex("0x0a").unwrap();
+        let scalar_15 = FieldElement::from_hex("0x0f").unwrap();
         let scalar_5_inverse = scalar_5.inverse();
         let witness_values = vec![
             scalar_5,
@@ -801,7 +823,7 @@ mod test {
             scalar_15,
             scalar_5,
             scalar_5_inverse,
-            Scalar::one(),
+            FieldElement::one(),
         ];
         let case_1 = WitnessResult {
             witness: witness_values.into(),

--- a/acvm_backend_barretenberg/src/composer.rs
+++ b/acvm_backend_barretenberg/src/composer.rs
@@ -1,4 +1,4 @@
-use common::barretenberg_structures::*;
+use common::barretenberg_structures::ConstraintSystem;
 use common::crs::{CRS, G2};
 use common::proof;
 

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -29,13 +29,6 @@ impl Assignments {
         buffer
     }
 
-    pub fn push_i32(&mut self, value: i32) {
-        self.0.push(Scalar::from(value as i128));
-    }
-    pub fn push(&mut self, value: Scalar) {
-        self.0.push(value);
-    }
-
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -4,14 +4,14 @@ use acvm::acir::BlackBoxFunc;
 
 pub use acvm::FieldElement as Scalar;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Assignments(Vec<Scalar>);
 pub type WitnessAssignments = Assignments;
 
 // This is a separate impl so the constructor can get the wasm_bindgen macro in the future
 impl Assignments {
     pub fn new() -> Assignments {
-        Assignments(vec![])
+        Assignments::default()
     }
 }
 
@@ -46,12 +46,6 @@ impl IntoIterator for Assignments {
 impl From<Vec<Scalar>> for Assignments {
     fn from(w: Vec<Scalar>) -> Assignments {
         Assignments(w)
-    }
-}
-
-impl Default for Assignments {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -1,11 +1,10 @@
 use acvm::acir::circuit::{Circuit, Opcode};
 use acvm::acir::native_types::Expression;
 use acvm::acir::BlackBoxFunc;
-
-pub use acvm::FieldElement as Scalar;
+use acvm::FieldElement;
 
 #[derive(Debug, Default, Clone)]
-pub struct Assignments(Vec<Scalar>);
+pub struct Assignments(Vec<FieldElement>);
 pub type WitnessAssignments = Assignments;
 
 // This is a separate impl so the constructor can get the wasm_bindgen macro in the future
@@ -35,7 +34,7 @@ impl Assignments {
 }
 
 impl IntoIterator for Assignments {
-    type Item = Scalar;
+    type Item = FieldElement;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -43,8 +42,8 @@ impl IntoIterator for Assignments {
     }
 }
 
-impl From<Vec<Scalar>> for Assignments {
-    fn from(w: Vec<Scalar>) -> Assignments {
+impl From<Vec<FieldElement>> for Assignments {
+    fn from(w: Vec<FieldElement>) -> Assignments {
         Assignments(w)
     }
 }
@@ -54,11 +53,11 @@ pub struct Constraint {
     pub a: i32,
     pub b: i32,
     pub c: i32,
-    pub qm: Scalar,
-    pub ql: Scalar,
-    pub qr: Scalar,
-    pub qo: Scalar,
-    pub qc: Scalar,
+    pub qm: FieldElement,
+    pub ql: FieldElement,
+    pub qr: FieldElement,
+    pub qo: FieldElement,
+    pub qc: FieldElement,
 }
 
 impl Constraint {
@@ -928,10 +927,10 @@ fn serialize_arithmetic_gates(gate: &Expression) -> Constraint {
     let mut a = 0;
     let mut b = 0;
     let mut c = 0;
-    let mut qm = Scalar::zero();
-    let mut ql = Scalar::zero();
-    let mut qr = Scalar::zero();
-    let mut qo = Scalar::zero();
+    let mut qm = FieldElement::zero();
+    let mut ql = FieldElement::zero();
+    let mut qr = FieldElement::zero();
+    let mut qo = FieldElement::zero();
 
     // check mul gate
     if !gate.mul_terms.is_empty() {

--- a/common/src/barretenberg_structures.rs
+++ b/common/src/barretenberg_structures.rs
@@ -5,7 +5,6 @@ use acvm::FieldElement;
 
 #[derive(Debug, Default, Clone)]
 pub struct Assignments(Vec<FieldElement>);
-pub type WitnessAssignments = Assignments;
 
 // This is a separate impl so the constructor can get the wasm_bindgen macro in the future
 impl Assignments {


### PR DESCRIPTION
I've removed some unused methods, derived default rather than defining it in terms of `new()` and replaced the usage of `Scalar` renaming of `FieldElement`.