### PR TITLE
feat!: Update to ACVM v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "pkg-config",
  "reqwest",
  "rust-embed",
- "sha3",
  "sled",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.10.3"
-source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084577e67b44c72d1cdfabe286d48adac6f5e0ad441ef134c5c467f4b6eee291"
 dependencies = [
  "acir_field",
  "flate2",
@@ -15,8 +16,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.10.3"
-source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a267ef529f4b132293199ecdf8c232ade817f01d916039f2d34562cab39e75e9"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -28,8 +30,9 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.10.3"
-source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1d6795105b50b13fa0dd1779b5191c4d8e9cd98b357b0b9a0b04a847baacf0"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -40,6 +43,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "sha2 0.9.9",
+ "sha3",
  "thiserror",
 ]
 
@@ -67,8 +71,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.10.3"
-source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3131af53d17ac12340c0ff50f8555d8e040321f8078b8ee3cd8846560b6a44a9"
 dependencies = [
  "acir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510b65efd4d20bf266185ce0a5dc7d29bcdd196a6a1835c20908fd88040de76c"
+source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,8 +16,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f032e710c67fd146caedc8fe1dea6e95f01ab59453e42d59b604a51fef3dfe"
+source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -31,8 +29,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2611266039740ffd1978f23258bd6ce3166c22cf15b8227685c2f3bb20ae2ee0"
+source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -63,6 +60,7 @@ dependencies = [
  "sha3",
  "sled",
  "tempfile",
+ "thiserror",
  "tokio",
  "wasmer",
 ]
@@ -70,8 +68,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ec51160c66eba75dc15a028a2391675386fd395b3897478d89a386c64a48dd"
+source = "git+https://github.com/noir-lang/acvm?rev=ba79379b4087a51a027f991ba6f7e6dff9c1c2a7#ba79379b4087a51a027f991ba6f7e6dff9c1c2a7"
 dependencies = [
  "acir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ acvm = { version = "0.11.0", features = ["bn254"] }
 thiserror = "1.0.21"
 
 blake2 = "0.9.1"
-sha3 = "0.9.1"
 dirs = { version = "3.0", optional = true }
 reqwest = { version = "0.11.16", optional = true, default-features = false, features = [
     "stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 acvm = { version = "0.10.3", features = ["bn254"] }
+thiserror = "1.0.21"
 
 blake2 = "0.9.1"
 sha3 = "0.9.1"
@@ -67,3 +68,6 @@ wasm = [
     "dep:indicatif",
 ]
 js = ["wasmer", "dep:rust-embed", "dep:getrandom", "wasmer/js-default"]
+
+[patch.crates-io]
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "ba79379b4087a51a027f991ba6f7e6dff9c1c2a7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { version = "0.10.3", features = ["bn254"] }
+acvm = { version = "0.11.0", features = ["bn254"] }
 thiserror = "1.0.21"
 
 blake2 = "0.9.1"
@@ -68,6 +68,3 @@ wasm = [
     "dep:indicatif",
 ]
 js = ["wasmer", "dep:rust-embed", "dep:getrandom", "wasmer/js-default"]
-
-[patch.crates-io]
-acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "ba79379b4087a51a027f991ba6f7e6dff9c1c2a7" }

--- a/cspell.json
+++ b/cspell.json
@@ -54,6 +54,7 @@
         "nixpkgs",
         "envrc",
         "subshell",
+        "thiserror",
         // In Solidity
         //
         "addmod",

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683235108,
-        "narHash": "sha256-2NN/pb9hwM5/qJ5mpJfGso1H3fc2RRaZ4sZhVPvT0Dw=",
+        "lastModified": 1683314474,
+        "narHash": "sha256-gfHYpOnVTfS+4fhScBhfkB/e5z+jPFCi8zSy+aEh+8s=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "e66f1ef38c3c87c223456d8a77878c2bd3d346eb",
+        "rev": "ad615ee7dc931d3dbea041e47c96b9d8dccebf98",
         "type": "github"
       },
       "original": {

--- a/src/acvm_interop/proof_system.rs
+++ b/src/acvm_interop/proof_system.rs
@@ -15,7 +15,7 @@ impl ProofSystemCompiler for Barretenberg {
     }
 
     fn get_exact_circuit_size(&self, circuit: &Circuit) -> Result<u32, Error> {
-        Composer::get_exact_circuit_size(self, &circuit.into())
+        Composer::get_exact_circuit_size(self, &circuit.try_into()?)
     }
 
     fn black_box_function_supported(&self, opcode: &BlackBoxFunc) -> bool {
@@ -38,7 +38,7 @@ impl ProofSystemCompiler for Barretenberg {
     }
 
     fn preprocess(&self, circuit: &Circuit) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        let constraint_system = &circuit.into();
+        let constraint_system = &circuit.try_into()?;
 
         let proving_key = self.compute_proving_key(constraint_system)?;
         let verification_key = self.compute_verification_key(constraint_system, &proving_key)?;
@@ -54,7 +54,7 @@ impl ProofSystemCompiler for Barretenberg {
     ) -> Result<Vec<u8>, Error> {
         let assignments = flatten_witness_map(circuit, witness_values);
 
-        self.create_proof_with_pk(&circuit.into(), assignments, proving_key)
+        self.create_proof_with_pk(&circuit.try_into()?, assignments, proving_key)
     }
 
     fn verify_with_vk(
@@ -70,7 +70,7 @@ impl ProofSystemCompiler for Barretenberg {
 
         Composer::verify_with_vk(
             self,
-            &circuit.into(),
+            &circuit.try_into()?,
             proof,
             flattened_public_inputs.into(),
             verification_key,

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -92,12 +92,28 @@ impl PartialWitnessGenerator for Barretenberg {
                     )
                 })?;
 
-                let mut signature = [0u8; 64];
-                for (i, sig) in signature.iter_mut().enumerate() {
+                let mut sig_s: [u8; 32] = [0u8; 32];
+                for (i, sig) in sig_s.iter_mut().enumerate() {
                     let _sig_i = inputs_iter.next().ok_or_else(|| {
                         OpcodeResolutionError::BlackBoxFunctionFailed(
                             func_call.name,
-                            format!("signature should be 64 bytes long, found only {i} bytes"),
+                            format!("sig_s should be 32 bytes long, found only {i} bytes"),
+                        )
+                    })?;
+                    let sig_i = witness_to_value(initial_witness, _sig_i.witness)?;
+                    *sig = *sig_i.to_be_bytes().last().ok_or_else(|| {
+                        OpcodeResolutionError::BlackBoxFunctionFailed(
+                            func_call.name,
+                            "could not get last bytes".into(),
+                        )
+                    })?;
+                }
+                let mut sig_e: [u8; 32] = [0u8; 32];
+                for (i, sig) in sig_e.iter_mut().enumerate() {
+                    let _sig_i = inputs_iter.next().ok_or_else(|| {
+                        OpcodeResolutionError::BlackBoxFunctionFailed(
+                            func_call.name,
+                            format!("sig_e should be 32 bytes long, found only {i} bytes"),
                         )
                     })?;
                     let sig_i = witness_to_value(initial_witness, _sig_i.witness)?;
@@ -122,7 +138,7 @@ impl PartialWitnessGenerator for Barretenberg {
                 }
 
                 let valid_signature = self
-                    .verify_signature(pub_key, signature, &message)
+                    .verify_signature(pub_key, sig_s, sig_e, &message)
                     .map_err(|err| {
                         OpcodeResolutionError::BlackBoxFunctionFailed(
                             func_call.name,

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -55,7 +55,9 @@ impl PartialWitnessGenerator for Barretenberg {
                     index,
                     leaf,
                 )
-                .map_err(|err| OpcodeResolutionError::OpcodeSolveFailed(err.to_string()))?;
+                .map_err(|err| {
+                    OpcodeResolutionError::BlackBoxFunctionFailed(func_call.name, err.to_string())
+                })?;
 
                 initial_witness.insert(func_call.outputs[0], computed_merkle_root);
                 Ok(OpcodeResolution::Solved)
@@ -84,23 +86,26 @@ impl PartialWitnessGenerator for Barretenberg {
                     .chain(pub_key_y.to_vec())
                     .collect();
                 let pub_key: [u8; 64] = pub_key_bytes.try_into().map_err(|v: Vec<u8>| {
-                    OpcodeResolutionError::OpcodeSolveFailed(format!(
-                        "expected pubkey size {} but received {}",
-                        64,
-                        v.len()
-                    ))
+                    OpcodeResolutionError::BlackBoxFunctionFailed(
+                        func_call.name,
+                        format!("expected pubkey size {} but received {}", 64, v.len()),
+                    )
                 })?;
 
                 let mut signature = [0u8; 64];
                 for (i, sig) in signature.iter_mut().enumerate() {
                     let _sig_i = inputs_iter.next().ok_or_else(|| {
-                        OpcodeResolutionError::OpcodeSolveFailed(format!(
-                            "signature should be 64 bytes long, found only {i} bytes"
-                        ))
+                        OpcodeResolutionError::BlackBoxFunctionFailed(
+                            func_call.name,
+                            format!("signature should be 64 bytes long, found only {i} bytes"),
+                        )
                     })?;
                     let sig_i = witness_to_value(initial_witness, _sig_i.witness)?;
                     *sig = *sig_i.to_be_bytes().last().ok_or_else(|| {
-                        OpcodeResolutionError::OpcodeSolveFailed("could not get last bytes".into())
+                        OpcodeResolutionError::BlackBoxFunctionFailed(
+                            func_call.name,
+                            "could not get last bytes".into(),
+                        )
                     })?;
                 }
 
@@ -108,14 +113,22 @@ impl PartialWitnessGenerator for Barretenberg {
                 for msg in inputs_iter {
                     let msg_i_field = witness_to_value(initial_witness, msg.witness)?;
                     let msg_i = *msg_i_field.to_be_bytes().last().ok_or_else(|| {
-                        OpcodeResolutionError::OpcodeSolveFailed("could not get last bytes".into())
+                        OpcodeResolutionError::BlackBoxFunctionFailed(
+                            func_call.name,
+                            "could not get last bytes".into(),
+                        )
                     })?;
                     message.push(msg_i);
                 }
 
                 let valid_signature = self
                     .verify_signature(pub_key, signature, &message)
-                    .map_err(|err| OpcodeResolutionError::OpcodeSolveFailed(err.to_string()))?;
+                    .map_err(|err| {
+                        OpcodeResolutionError::BlackBoxFunctionFailed(
+                            func_call.name,
+                            err.to_string(),
+                        )
+                    })?;
                 if !valid_signature {
                     dbg!("signature has failed to verify");
                 }
@@ -137,9 +150,9 @@ impl PartialWitnessGenerator for Barretenberg {
                     .collect();
                 let scalars: Vec<_> = scalars?.into_iter().cloned().collect();
 
-                let (res_x, res_y) = self
-                    .encrypt(scalars)
-                    .map_err(|err| OpcodeResolutionError::OpcodeSolveFailed(err.to_string()))?;
+                let (res_x, res_y) = self.encrypt(scalars).map_err(|err| {
+                    OpcodeResolutionError::BlackBoxFunctionFailed(func_call.name, err.to_string())
+                })?;
                 initial_witness.insert(func_call.outputs[0], res_x);
                 initial_witness.insert(func_call.outputs[1], res_y);
                 Ok(OpcodeResolution::Solved)
@@ -169,9 +182,9 @@ impl PartialWitnessGenerator for Barretenberg {
             BlackBoxFunc::FixedBaseScalarMul => {
                 let scalar = witness_to_value(initial_witness, func_call.inputs[0].witness)?;
 
-                let (pub_x, pub_y) = self
-                    .fixed_base(scalar)
-                    .map_err(|err| OpcodeResolutionError::OpcodeSolveFailed(err.to_string()))?;
+                let (pub_x, pub_y) = self.fixed_base(scalar).map_err(|err| {
+                    OpcodeResolutionError::BlackBoxFunctionFailed(func_call.name, err.to_string())
+                })?;
 
                 initial_witness.insert(func_call.outputs[0], pub_x);
                 initial_witness.insert(func_call.outputs[1], pub_y);

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -24,7 +24,7 @@ impl PartialWitnessGenerator for Barretenberg {
         match func_call.name {
             BlackBoxFunc::SHA256 => hash::sha256(initial_witness, func_call),
             BlackBoxFunc::Blake2s => hash::blake2s(initial_witness, func_call),
-            BlackBoxFunc::Keccak256 => keccak256(initial_witness, func_call),
+            BlackBoxFunc::Keccak256 => hash::keccak256(initial_witness, func_call),
             BlackBoxFunc::EcdsaSecp256k1 => {
                 signature::ecdsa::secp256k1_prehashed(initial_witness, func_call)
             }
@@ -192,60 +192,4 @@ impl PartialWitnessGenerator for Barretenberg {
             }
         }
     }
-}
-
-// All of the code below can be removed once we update to acvm 0.11 or greater.
-use sha3::Keccak256;
-fn keccak256(
-    initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
-) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    let hash = generic_hash_256::<Keccak256>(initial_witness, func_call)?;
-
-    for (output_witness, value) in func_call.outputs.iter().zip(hash.iter()) {
-        insert_value(
-            output_witness,
-            FieldElement::from_be_bytes_reduce(&[*value]),
-            initial_witness,
-        )?;
-    }
-
-    Ok(OpcodeResolution::Solved)
-}
-fn insert_value(
-    witness: &Witness,
-    value_to_insert: FieldElement,
-    initial_witness: &mut BTreeMap<Witness, FieldElement>,
-) -> Result<(), OpcodeResolutionError> {
-    let optional_old_value = initial_witness.insert(*witness, value_to_insert);
-
-    let old_value = match optional_old_value {
-        Some(old_value) => old_value,
-        None => return Ok(()),
-    };
-
-    if old_value != value_to_insert {
-        return Err(OpcodeResolutionError::UnsatisfiedConstrain);
-    }
-
-    Ok(())
-}
-fn generic_hash_256<D: Digest>(
-    initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
-) -> Result<[u8; 32], OpcodeResolutionError> {
-    let mut hasher = D::new();
-
-    // Read witness assignments into hasher.
-    for input in func_call.inputs.iter() {
-        let witness = input.witness;
-        let num_bits = input.num_bits as usize;
-
-        let witness_assignment = witness_to_value(initial_witness, witness)?;
-        let bytes = witness_assignment.fetch_nearest_bytes(num_bits);
-        hasher.update(bytes);
-    }
-
-    let result = hasher.finalize().as_slice().try_into().unwrap();
-    Ok(result)
 }

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -58,7 +58,7 @@ impl SmartContract for Barretenberg {
 
         // We then need to read the pointer at `contract_ptr_ptr` to get the smart contract's location
         // and then slice memory again at `contract_ptr_ptr` to get the smart contract string.
-        let contract_ptr = self.get_pointer(contract_ptr_ptr)?;
+        let contract_ptr = self.get_pointer(contract_ptr_ptr);
 
         let sc_as_bytes = self.read_memory_variable_length(contract_ptr, contract_size);
 

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -1,16 +1,16 @@
 use acvm::SmartContract;
 
 use crate::crs::G2;
-use crate::{Barretenberg, Error};
+use crate::{BackendError, Barretenberg};
 
 /// Embed the Solidity verifier file
 const ULTRA_VERIFIER_CONTRACT: &str = include_str!("contract.sol");
 
 #[cfg(feature = "native")]
 impl SmartContract for Barretenberg {
-    type Error = Error;
+    type Error = BackendError;
 
-    fn eth_contract_from_vk(&self, verification_key: &[u8]) -> Result<String, Error> {
+    fn eth_contract_from_vk(&self, verification_key: &[u8]) -> Result<String, Self::Error> {
         use std::slice;
 
         let g2 = G2::new();
@@ -38,9 +38,9 @@ impl SmartContract for Barretenberg {
 
 #[cfg(not(feature = "native"))]
 impl SmartContract for Barretenberg {
-    type Error = Error;
+    type Error = BackendError;
 
-    fn eth_contract_from_vk(&self, verification_key: &[u8]) -> Result<String, Error> {
+    fn eth_contract_from_vk(&self, verification_key: &[u8]) -> Result<String, Self::Error> {
         let g2 = G2::new();
 
         let g2_ptr = self.allocate(&g2.data)?;
@@ -69,7 +69,7 @@ impl SmartContract for Barretenberg {
 }
 
 #[test]
-fn test_smart_contract() -> Result<(), Error> {
+fn test_smart_contract() -> Result<(), BackendError> {
     use crate::barretenberg_structures::{Constraint, ConstraintSystem};
     use crate::composer::Composer;
     use crate::Barretenberg;

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -54,13 +54,12 @@ impl SmartContract for Barretenberg {
             "acir_proofs_get_solidity_verifier",
             vec![&g2_ptr, &vk_ptr, &contract_ptr_ptr.into()],
         )?;
-        let contract_size: usize = contract_size.i32()? as usize;
 
         // We then need to read the pointer at `contract_ptr_ptr` to get the smart contract's location
         // and then slice memory again at `contract_ptr_ptr` to get the smart contract string.
         let contract_ptr = self.get_pointer(contract_ptr_ptr);
 
-        let sc_as_bytes = self.read_memory_variable_length(contract_ptr, contract_size);
+        let sc_as_bytes = self.read_memory_variable_length(contract_ptr, contract_size.try_into()?);
 
         let verification_key_library: String = sc_as_bytes.iter().map(|b| *b as char).collect();
         Ok(format!(

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -971,11 +971,8 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut outputs_iter = gadget_call.outputs.iter();
                             let mut result = [0i32; 32];
                             for (i, res) in result.iter_mut().enumerate() {
-                                let out_byte = outputs_iter.next().unwrap_or_else(|| {
-                                    panic!(
-                                        "missing rest of output. Tried to get byte {i} but failed"
-                                    )
-                                });
+                                let out_byte =
+                                    outputs_iter.next().ok_or(Error::MissingOutput(i))?;
 
                                 let out_byte_index = out_byte.witness_index() as i32;
                                 *res = out_byte_index

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -734,8 +734,12 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut outputs_iter = gadget_call.outputs.iter();
                             let mut result = [0i32; 32];
                             for (i, res) in result.iter_mut().enumerate() {
-                                let out_byte =
-                                    outputs_iter.next().ok_or(Error::MissingOutput(i))?;
+                                let out_byte = outputs_iter.next().ok_or_else(|| {
+                                    Error::MalformedBlackBoxFunc(
+                                        gadget_call.name,
+                                        format!("Missing rest of output. Tried to get byte {i} but failed"),
+                                    )
+                                })?;
 
                                 let out_byte_index = out_byte.witness_index() as i32;
                                 *res = out_byte_index
@@ -761,7 +765,12 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut result = [0i32; 32];
                             for (i, res) in result.iter_mut().enumerate() {
                                 let out_byte =
-                                    outputs_iter.next().ok_or(Error::MissingOutput(i))?;
+                                    outputs_iter.next().ok_or_else(|| {
+                                        Error::MalformedBlackBoxFunc(
+                                            gadget_call.name,
+                                            format!("Missing rest of output. Tried to get byte {i} but failed"),
+                                        )
+                                    })?;
 
                                 let out_byte_index = out_byte.witness_index() as i32;
                                 *res = out_byte_index
@@ -778,13 +787,22 @@ impl TryFrom<&Circuit> for ConstraintSystem {
 
                             // leaf
                             let leaf = {
-                                let leaf_input = inputs_iter.next().ok_or(Error::MissingLeaf)?;
+                                let leaf_input = inputs_iter.next().ok_or_else(|| {
+                                    Error::MalformedBlackBoxFunc(
+                                        gadget_call.name,
+                                        "Missing leaf to check membership for".into(),
+                                    )
+                                })?;
                                 leaf_input.witness.witness_index() as i32
                             };
                             // index
                             let index = {
-                                let index_input =
-                                    inputs_iter.next().ok_or(Error::MissingLeafIndex)?;
+                                let index_input = inputs_iter.next().ok_or_else(|| {
+                                    Error::MalformedBlackBoxFunc(
+                                        gadget_call.name,
+                                        "Missing index for leaf".into(),
+                                    )
+                                })?;
                                 index_input.witness.witness_index() as i32
                             };
 
@@ -816,21 +834,35 @@ impl TryFrom<&Circuit> for ConstraintSystem {
 
                             // pub_key_x
                             let public_key_x = {
-                                let pub_key_x =
-                                    inputs_iter.next().ok_or(Error::MissingPublicKeyX)?;
+                                let pub_key_x = inputs_iter.next().ok_or_else(|| {
+                                    Error::MalformedBlackBoxFunc(
+                                        gadget_call.name,
+                                        "Missing `x` component for public key".into(),
+                                    )
+                                })?;
                                 pub_key_x.witness.witness_index() as i32
                             };
                             // pub_key_y
                             let public_key_y = {
-                                let pub_key_y =
-                                    inputs_iter.next().ok_or(Error::MissingPublicKeyY)?;
+                                let pub_key_y = inputs_iter.next().ok_or_else(|| {
+                                    Error::MalformedBlackBoxFunc(
+                                        gadget_call.name,
+                                        "Missing `y` component for public key".into(),
+                                    )
+                                })?;
                                 pub_key_y.witness.witness_index() as i32
                             };
                             // signature
+
                             let mut signature = [0i32; 64];
                             for (i, sig) in signature.iter_mut().enumerate() {
                                 let sig_byte =
-                                    inputs_iter.next().ok_or(Error::MissingSignature(i))?;
+                                    inputs_iter.next().ok_or_else(|| {
+                                        Error::MalformedBlackBoxFunc(
+                                            gadget_call.name,
+                                            format!("Missing rest of signature. Tried to get byte {i} but failed"),
+                                        )
+                                    })?;
                                 let sig_byte_index = sig_byte.witness.witness_index() as i32;
                                 *sig = sig_byte_index
                             }
@@ -899,7 +931,12 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut public_key_x = [0i32; 32];
                             for (i, pkx) in public_key_x.iter_mut().enumerate() {
                                 let x_byte =
-                                    inputs_iter.next().ok_or(Error::MissingPublicKey("x", i))?;
+                                    inputs_iter.next().ok_or_else(|| {
+                                        Error::MalformedBlackBoxFunc(
+                                            gadget_call.name,
+                                            format!("Missing rest of `x` component for public key. Tried to get byte {i} but failed"),
+                                        )
+                                    })?;
                                 let x_byte_index = x_byte.witness.witness_index() as i32;
                                 *pkx = x_byte_index;
                             }
@@ -908,7 +945,12 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut public_key_y = [0i32; 32];
                             for (i, pky) in public_key_y.iter_mut().enumerate() {
                                 let y_byte =
-                                    inputs_iter.next().ok_or(Error::MissingPublicKey("y", i))?;
+                                    inputs_iter.next().ok_or_else(|| {
+                                        Error::MalformedBlackBoxFunc(
+                                            gadget_call.name,
+                                            format!("Missing rest of `y` component for public key. Tried to get byte {i} but failed"),
+                                        )
+                                    })?;
                                 let y_byte_index = y_byte.witness.witness_index() as i32;
                                 *pky = y_byte_index;
                             }
@@ -917,7 +959,12 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut signature = [0i32; 64];
                             for (i, sig) in signature.iter_mut().enumerate() {
                                 let sig_byte =
-                                    inputs_iter.next().ok_or(Error::MissingSignature(i))?;
+                                    inputs_iter.next().ok_or_else(|| {
+                                        Error::MalformedBlackBoxFunc(
+                                            gadget_call.name,
+                                            format!("Missing rest of signature. Tried to get byte {i} but failed"),
+                                        )
+                                    })?;
                                 let sig_byte_index = sig_byte.witness.witness_index() as i32;
                                 *sig = sig_byte_index;
                             }
@@ -972,7 +1019,12 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                             let mut result = [0i32; 32];
                             for (i, res) in result.iter_mut().enumerate() {
                                 let out_byte =
-                                    outputs_iter.next().ok_or(Error::MissingOutput(i))?;
+                                    outputs_iter.next().ok_or_else(|| {
+                                        Error::MalformedBlackBoxFunc(
+                                            gadget_call.name,
+                                            format!("Missing rest of output. Tried to get byte {i} but failed"),
+                                        )
+                                    })?;
 
                                 let out_byte_index = out_byte.witness_index() as i32;
                                 *res = out_byte_index
@@ -984,7 +1036,9 @@ impl TryFrom<&Circuit> for ConstraintSystem {
 
                             keccak_constraints.push(keccak_constraint);
                         }
-                        BlackBoxFunc::AES => return Err(Error::Aes),
+                        BlackBoxFunc::AES => {
+                            return Err(Error::UnsupportedBlackBoxFunc(gadget_call.name))
+                        }
                     };
                 }
                 Opcode::Directive(_) | Opcode::Oracle(_) => {

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -3,6 +3,8 @@ use acvm::acir::native_types::Expression;
 use acvm::acir::BlackBoxFunc;
 use acvm::FieldElement;
 
+use crate::Error;
+
 #[derive(Debug, Default, Clone)]
 pub(crate) struct Assignments(Vec<FieldElement>);
 
@@ -643,10 +645,11 @@ impl ConstraintSystem {
     }
 }
 
-// TODO: TryFrom
-impl From<&Circuit> for ConstraintSystem {
+impl TryFrom<&Circuit> for ConstraintSystem {
+    type Error = Error;
+
     /// Converts an `IR` into the `StandardFormat` constraint system
-    fn from(circuit: &Circuit) -> Self {
+    fn try_from(circuit: &Circuit) -> Result<Self, Self::Error> {
         // Create constraint system
         let mut constraints: Vec<Constraint> = Vec::new();
         let mut range_constraints: Vec<RangeConstraint> = Vec::new();
@@ -731,11 +734,8 @@ impl From<&Circuit> for ConstraintSystem {
                             let mut outputs_iter = gadget_call.outputs.iter();
                             let mut result = [0i32; 32];
                             for (i, res) in result.iter_mut().enumerate() {
-                                let out_byte = outputs_iter.next().unwrap_or_else(|| {
-                                    panic!(
-                                        "missing rest of output. Tried to get byte {i} but failed"
-                                    )
-                                });
+                                let out_byte =
+                                    outputs_iter.next().ok_or(Error::MissingOutput(i))?;
 
                                 let out_byte_index = out_byte.witness_index() as i32;
                                 *res = out_byte_index
@@ -760,11 +760,8 @@ impl From<&Circuit> for ConstraintSystem {
                             let mut outputs_iter = gadget_call.outputs.iter();
                             let mut result = [0i32; 32];
                             for (i, res) in result.iter_mut().enumerate() {
-                                let out_byte = outputs_iter.next().unwrap_or_else(|| {
-                                    panic!(
-                                        "missing rest of output. Tried to get byte {i} but failed"
-                                    )
-                                });
+                                let out_byte =
+                                    outputs_iter.next().ok_or(Error::MissingOutput(i))?;
 
                                 let out_byte_index = out_byte.witness_index() as i32;
                                 *res = out_byte_index
@@ -781,15 +778,13 @@ impl From<&Circuit> for ConstraintSystem {
 
                             // leaf
                             let leaf = {
-                                let leaf_input = inputs_iter
-                                    .next()
-                                    .expect("missing leaf to check membership for");
+                                let leaf_input = inputs_iter.next().ok_or(Error::MissingLeaf)?;
                                 leaf_input.witness.witness_index() as i32
                             };
                             // index
                             let index = {
                                 let index_input =
-                                    inputs_iter.next().expect("missing index for leaf");
+                                    inputs_iter.next().ok_or(Error::MissingLeafIndex)?;
                                 index_input.witness.witness_index() as i32
                             };
 
@@ -821,26 +816,21 @@ impl From<&Circuit> for ConstraintSystem {
 
                             // pub_key_x
                             let public_key_x = {
-                                let pub_key_x = inputs_iter
-                                    .next()
-                                    .expect("missing `x` component for public key");
+                                let pub_key_x =
+                                    inputs_iter.next().ok_or(Error::MissingPublicKeyX)?;
                                 pub_key_x.witness.witness_index() as i32
                             };
                             // pub_key_y
                             let public_key_y = {
-                                let pub_key_y = inputs_iter
-                                    .next()
-                                    .expect("missing `y` component for public key");
+                                let pub_key_y =
+                                    inputs_iter.next().ok_or(Error::MissingPublicKeyY)?;
                                 pub_key_y.witness.witness_index() as i32
                             };
                             // signature
                             let mut signature = [0i32; 64];
                             for (i, sig) in signature.iter_mut().enumerate() {
-                                let sig_byte = inputs_iter.next().unwrap_or_else(|| {
-                                    panic!(
-                                    "missing rest of signature. Tried to get byte {i} but failed",
-                                )
-                                });
+                                let sig_byte =
+                                    inputs_iter.next().ok_or(Error::MissingSignature(i))?;
                                 let sig_byte_index = sig_byte.witness.witness_index() as i32;
                                 *sig = sig_byte_index
                             }
@@ -908,7 +898,8 @@ impl From<&Circuit> for ConstraintSystem {
                             // public key x
                             let mut public_key_x = [0i32; 32];
                             for (i, pkx) in public_key_x.iter_mut().enumerate() {
-                                let x_byte = inputs_iter.next().unwrap_or_else(|| panic!("missing rest of x component for public key. Tried to get byte {i} but failed"));
+                                let x_byte =
+                                    inputs_iter.next().ok_or(Error::MissingPublicKey("x", i))?;
                                 let x_byte_index = x_byte.witness.witness_index() as i32;
                                 *pkx = x_byte_index;
                             }
@@ -916,7 +907,8 @@ impl From<&Circuit> for ConstraintSystem {
                             // public key y
                             let mut public_key_y = [0i32; 32];
                             for (i, pky) in public_key_y.iter_mut().enumerate() {
-                                let y_byte = inputs_iter.next().unwrap_or_else(|| panic!("missing rest of y component for public key. Tried to get byte {i} but failed"));
+                                let y_byte =
+                                    inputs_iter.next().ok_or(Error::MissingPublicKey("y", i))?;
                                 let y_byte_index = y_byte.witness.witness_index() as i32;
                                 *pky = y_byte_index;
                             }
@@ -924,11 +916,8 @@ impl From<&Circuit> for ConstraintSystem {
                             // signature
                             let mut signature = [0i32; 64];
                             for (i, sig) in signature.iter_mut().enumerate() {
-                                let sig_byte = inputs_iter.next().unwrap_or_else(|| {
-                                    panic!(
-                                    "missing rest of signature. Tried to get byte {i} but failed",
-                                )
-                                });
+                                let sig_byte =
+                                    inputs_iter.next().ok_or(Error::MissingSignature(i))?;
                                 let sig_byte_index = sig_byte.witness.witness_index() as i32;
                                 *sig = sig_byte_index;
                             }
@@ -998,7 +987,7 @@ impl From<&Circuit> for ConstraintSystem {
 
                             keccak_constraints.push(keccak_constraint);
                         }
-                        BlackBoxFunc::AES => panic!("AES has not yet been implemented"),
+                        BlackBoxFunc::AES => return Err(Error::Aes),
                     };
                 }
                 Opcode::Directive(_) | Opcode::Oracle(_) => {
@@ -1011,7 +1000,7 @@ impl From<&Circuit> for ConstraintSystem {
         }
 
         // Create constraint system
-        ConstraintSystem {
+        Ok(ConstraintSystem {
             var_num: circuit.current_witness_index + 1, // number of witnesses is the witness index + 1;
             public_inputs: circuit.public_inputs().indices(),
             logic_constraints,
@@ -1026,7 +1015,7 @@ impl From<&Circuit> for ConstraintSystem {
             hash_to_field_constraints,
             constraints,
             fixed_base_scalar_mul_constraints,
-        }
+        })
     }
 }
 

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -643,6 +643,7 @@ impl ConstraintSystem {
     }
 }
 
+// TODO: TryFrom
 impl From<&Circuit> for ConstraintSystem {
     /// Converts an `IR` into the `StandardFormat` constraint system
     fn from(circuit: &Circuit) -> Self {

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -280,7 +280,7 @@ impl Composer for Barretenberg {
         let vk_size = self
             .call_multiple(
                 "acir_proofs_init_verification_key",
-                vec![&pippenger_ptr.into(), &g2_ptr, &pk_ptr, &vk_ptr_ptr.into()],
+                vec![&pippenger_ptr, &g2_ptr, &pk_ptr, &vk_ptr_ptr.into()],
             )?
             .i32()?;
 
@@ -318,7 +318,7 @@ impl Composer for Barretenberg {
             .call_multiple(
                 "acir_proofs_new_proof",
                 vec![
-                    &pippenger_ptr.into(),
+                    &pippenger_ptr,
                     &g2_ptr,
                     &pk_ptr,
                     &cs_ptr,

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -61,9 +61,13 @@ impl Composer for Barretenberg {
     fn get_exact_circuit_size(&self, constraint_system: &ConstraintSystem) -> Result<u32, Error> {
         let cs_buf = constraint_system.to_bytes();
 
-        Ok(unsafe {
-            barretenberg_sys::composer::get_exact_circuit_size(cs_buf.as_slice().as_ptr())
-        })
+        let circuit_size;
+        unsafe {
+            circuit_size =
+                barretenberg_sys::composer::get_exact_circuit_size(cs_buf.as_slice().as_ptr())
+        }
+
+        Ok(circuit_size)
     }
 
     fn compute_proving_key(&self, constraint_system: &ConstraintSystem) -> Result<Vec<u8>, Error> {

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -232,7 +232,9 @@ impl Composer for Barretenberg {
 
         self.free(cs_ptr)?;
 
-        circuit_size?.u32()
+        let size = circuit_size?.u32()?;
+
+        Ok(size)
     }
 
     fn compute_proving_key(&self, constraint_system: &ConstraintSystem) -> Result<Vec<u8>, Error> {
@@ -368,7 +370,9 @@ impl Composer for Barretenberg {
 
         self.free(proof_ptr)?;
 
-        verified?.bool()
+        let verified = verified?.bool()?;
+
+        Ok(verified)
     }
 }
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -254,9 +254,9 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `pk_ptr_ptr` to get the key's location
         // and then slice memory again at `pk_ptr` to get the proving key.
-        let pk_ptr = self.get_pointer(pk_ptr_ptr)?;
+        let pk_ptr = self.get_pointer(pk_ptr_ptr);
 
-        Ok(self.read_memory_variable_length(pk_ptr, pk_size))
+        Ok(self.read_memory_variable_length(pk_ptr, pk_size as usize))
     }
 
     fn compute_verification_key(
@@ -286,9 +286,9 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `vk_ptr_ptr` to get the key's location
         // and then slice memory again at `vk_ptr` to get the verification key.
-        let vk_ptr = self.get_pointer(vk_ptr_ptr)?;
+        let vk_ptr = self.get_pointer(vk_ptr_ptr);
 
-        Ok(self.read_memory_variable_length(vk_ptr, vk_size))
+        Ok(self.read_memory_variable_length(vk_ptr, vk_size as usize))
     }
 
     fn create_proof_with_pk(
@@ -330,9 +330,9 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `proof_ptr_ptr` to get the proof's location
         // and then slice memory again at `proof_ptr` to get the proof data.
-        let proof_ptr = self.get_pointer(proof_ptr_ptr)?;
+        let proof_ptr = self.get_pointer(proof_ptr_ptr);
 
-        let result = self.read_memory_variable_length(proof_ptr, proof_size);
+        let result = self.read_memory_variable_length(proof_ptr, proof_size as usize);
 
         // Barretenberg returns proofs which are prepended with the public inputs.
         // This behavior is nonstandard so we strip the public inputs from the proof.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,6 @@ use thiserror::Error;
 #[cfg(feature = "native")]
 #[derive(Debug, Error)]
 enum FeatureError {
-    #[error("Could not slice schnorr")]
-    SchnorrSlice {
-        source: std::array::TryFromSliceError,
-    },
     #[error("Could not slice field element")]
     FieldElementSlice {
         source: std::array::TryFromSliceError,
@@ -73,8 +69,6 @@ enum FeatureError {
 enum Error {
     #[error("The value {0} overflows in the pow2ceil function")]
     Pow2CeilOverflow(u32),
-    #[error("Could not convert schnorr")]
-    SchnorrConvert(Vec<u8>),
 
     #[error("Malformed Black Box Function: {0} - {1}")]
     MalformedBlackBoxFunc(BlackBoxFunc, String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod pippenger;
 mod scalar_mul;
 mod schnorr;
 
+use acvm::acir::BlackBoxFunc;
 use thiserror::Error;
 
 #[cfg(feature = "native")]
@@ -75,26 +76,14 @@ enum Error {
     #[error("Could not convert schnorr")]
     SchnorrConvert(Vec<u8>),
 
-    #[error("Missing rest of output. Tried to get byte {0} but failed")]
-    MissingOutput(usize),
-    #[error("Missing leaf to check membership for")]
-    MissingLeaf,
-    #[error("Missing index for leaf")]
-    MissingLeafIndex,
-    #[error("Missing `x` component for public key")]
-    MissingPublicKeyX,
-    #[error("Missing `y` component for public key")]
-    MissingPublicKeyY,
-    #[error("Missing rest of signature. Tried to get byte {0} but failed")]
-    MissingSignature(usize),
-    #[error("Missing rest of {0} component for public key. Tried to get byte {1} but failed")]
-    MissingPublicKey(&'static str, usize),
+    #[error("Malformed Black Box Function: {0} - {1}")]
+    MalformedBlackBoxFunc(BlackBoxFunc, String),
 
-    #[error("AES has not yet been implemented")]
-    Aes,
+    #[error("Unsupported Black Box Function: {0}")]
+    UnsupportedBlackBoxFunc(BlackBoxFunc),
 
     #[error(transparent)]
-    FeatureError(#[from] FeatureError),
+    FromFeature(#[from] FeatureError),
 }
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,6 @@ pub enum WasmError {
     },
     #[error("Value expected to be 0 or 1 representing a boolean")]
     InvalidBool,
-    #[error("Failed to get pointer")]
-    InvalidPointer { source: TryFromSliceError },
 }
 
 #[derive(Debug, Error)]
@@ -89,8 +87,7 @@ pub enum Error {
     MissingSignature(usize),
     #[error("Missing rest of {0} component for public key. Tried to get byte {1} but failed")]
     MissingPublicKey(&'static str, usize),
-    #[error("Keccak256 has not yet been implemented")]
-    Keccak256,
+
     #[error("AES has not yet been implemented")]
     Aes,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,32 +229,6 @@ mod wasm {
         fn try_from(x: WASMValue) -> Result<Self, Self::Error> {
             x.value()
         }
-
-        pub(super) fn bool(self) -> bool {
-            match self.i32() {
-                0 => false,
-                1 => true,
-                _ => panic!("expected a boolean value"),
-            }
-        }
-    }
-
-    impl From<usize> for WASMValue {
-        fn from(value: usize) -> Self {
-            WASMValue(Some(Value::I32(value as i32)))
-        }
-    }
-
-    impl From<i32> for WASMValue {
-        fn from(value: i32) -> Self {
-            WASMValue(Some(Value::I32(value)))
-        }
-    }
-
-    impl From<Value> for WASMValue {
-        fn from(value: Value) -> Self {
-            WASMValue(Some(value))
-        }
     }
 
     impl Barretenberg {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ enum FeatureError {
         value: i32,
         source: std::num::TryFromIntError,
     },
-    #[error("Could not convert value {value} from i32 to usuze")]
+    #[error("Could not convert value {value} from i32 to usize")]
     InvalidUsize {
         value: i32,
         source: std::num::TryFromIntError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub enum Error {
 /// The number of bytes necessary to store a `FieldElement`.
 const FIELD_BYTES: usize = 32;
 
+#[derive(Debug)]
 pub struct Barretenberg {
     #[cfg(feature = "wasm")]
     memory: wasmer::Memory,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,7 @@ mod wasm {
             }
         }
 
+        // TODO: Consider making this Result-returning
         pub(super) fn read_memory<const SIZE: usize>(&self, start: usize) -> [u8; SIZE] {
             self.read_memory_variable_length(start, SIZE)
                 .try_into()
@@ -276,13 +277,9 @@ mod wasm {
                 .collect();
         }
 
-        pub(super) fn get_pointer(&self, ptr_ptr: usize) -> Result<usize, Error> {
-            let ptr = self.slice_memory(ptr_ptr, POINTER_BYTES);
-            Ok(u32::from_le_bytes(
-                ptr[0..POINTER_BYTES]
-                    .try_into()
-                    .map_err(|source| WasmError::InvalidPointer { source })?,
-            ) as usize)
+        pub(super) fn get_pointer(&self, ptr_ptr: usize) -> usize {
+            let ptr: [u8; POINTER_BYTES] = self.read_memory(ptr_ptr);
+            u32::from_le_bytes(ptr) as usize
         }
 
         pub(super) fn call(&self, name: &str, param: &WASMValue) -> Result<WASMValue, Error> {

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,16 +1,16 @@
 use acvm::FieldElement;
 use std::{convert::TryInto, path::Path};
 
-use crate::{pedersen::Pedersen, Barretenberg};
+use crate::{pedersen::Pedersen, Barretenberg, Error};
 
 // Hashes the leaves up the path, on the way to the root
 pub(crate) trait PathHasher {
     fn new() -> Self;
-    fn hash(&self, left: &FieldElement, right: &FieldElement) -> FieldElement;
+    fn hash(&self, left: &FieldElement, right: &FieldElement) -> Result<FieldElement, Error>;
 }
 
 impl PathHasher for Barretenberg {
-    fn hash(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    fn hash(&self, left: &FieldElement, right: &FieldElement) -> Result<FieldElement, Error> {
         self.compress_native(left, right)
     }
 
@@ -65,6 +65,7 @@ pub(crate) struct MerkleTree<MH: MessageHasher, PH: PathHasher> {
     msg_hasher: MH,
 }
 
+// TODO: Rework this module to return results
 fn insert_root(db: &mut sled::Db, value: FieldElement) {
     db.insert("ROOT".as_bytes(), value.to_be_bytes()).unwrap();
 }
@@ -202,7 +203,8 @@ impl<MH: MessageHasher, PH: PathHasher> MerkleTree<MH, PH> {
             for i in 0..layer_size {
                 hashes[offset + i] = current;
             }
-            current = barretenberg.hash(&current, &current);
+            // TODO: no unwrap
+            current = barretenberg.hash(&current, &current).unwrap();
 
             offset += layer_size;
             layer_size /= 2;
@@ -248,7 +250,11 @@ impl<MH: MessageHasher, PH: PathHasher> MerkleTree<MH, PH> {
         path
     }
     /// Updates the message at index and computes the new tree root
-    pub(crate) fn update_message(&mut self, index: usize, new_message: &[u8]) -> FieldElement {
+    pub(crate) fn update_message(
+        &mut self,
+        index: usize,
+        new_message: &[u8],
+    ) -> Result<FieldElement, Error> {
         let current = self.msg_hasher.hash(new_message);
 
         insert_preimage(&mut self.db, index as u32, new_message.to_vec());
@@ -285,7 +291,7 @@ impl<MH: MessageHasher, PH: PathHasher> MerkleTree<MH, PH> {
         &mut self,
         mut index: usize,
         mut current: FieldElement,
-    ) -> FieldElement {
+    ) -> Result<FieldElement, Error> {
         // Note that this method does not update the list of messages [preimages]|
         // use `update_message` to do this
         self.check_if_index_valid_and_increment(index);
@@ -299,7 +305,7 @@ impl<MH: MessageHasher, PH: PathHasher> MerkleTree<MH, PH> {
             current = self.barretenberg.hash(
                 &fetch_hash(&self.db, offset + index),
                 &fetch_hash(&self.db, offset + index + 1),
-            );
+            )?;
 
             offset += layer_size as usize;
             layer_size /= 2;
@@ -307,7 +313,7 @@ impl<MH: MessageHasher, PH: PathHasher> MerkleTree<MH, PH> {
         }
 
         insert_root(&mut self.db, current);
-        current
+        Ok(current)
     }
 
     #[allow(dead_code)]
@@ -368,20 +374,20 @@ fn basic_interop_hashpath() {
 }
 
 #[test]
-fn basic_interop_update() {
+fn basic_interop_update() -> Result<(), Error> {
     // Test that computing the HashPath is correct
     use tempfile::tempdir;
     let temp_dir = tempdir().unwrap();
     let mut tree: MerkleTree<blake2::Blake2s, Barretenberg> = MerkleTree::new(3, &temp_dir);
 
-    tree.update_message(0, &[0; 64]);
-    tree.update_message(1, &[1; 64]);
-    tree.update_message(2, &[2; 64]);
-    tree.update_message(3, &[3; 64]);
-    tree.update_message(4, &[4; 64]);
-    tree.update_message(5, &[5; 64]);
-    tree.update_message(6, &[6; 64]);
-    let root = tree.update_message(7, &[7; 64]);
+    tree.update_message(0, &[0; 64])?;
+    tree.update_message(1, &[1; 64])?;
+    tree.update_message(2, &[2; 64])?;
+    tree.update_message(3, &[3; 64])?;
+    tree.update_message(4, &[4; 64])?;
+    tree.update_message(5, &[5; 64])?;
+    tree.update_message(6, &[6; 64])?;
+    let root = tree.update_message(7, &[7; 64])?;
 
     assert_eq!(
         "0ef8e14db4762ebddadb23b2225f93ca200a4c9bd37130b4d028c971bbad16b5",
@@ -409,4 +415,6 @@ fn basic_interop_update() {
         assert_eq!(got.0.to_hex().as_str(), expected_segment.0);
         assert_eq!(got.1.to_hex().as_str(), expected_segment.1)
     }
+
+    Ok(())
 }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,3 +1,4 @@
+// TODO(#166): Rework this module to return results
 use acvm::FieldElement;
 use std::{convert::TryInto, path::Path};
 
@@ -65,7 +66,6 @@ pub(crate) struct MerkleTree<MH: MessageHasher, PH: PathHasher> {
     msg_hasher: MH,
 }
 
-// TODO: Rework this module to return results
 fn insert_root(db: &mut sled::Db, value: FieldElement) {
     db.insert("ROOT".as_bytes(), value.to_be_bytes()).unwrap();
 }
@@ -203,7 +203,6 @@ impl<MH: MessageHasher, PH: PathHasher> MerkleTree<MH, PH> {
             for i in 0..layer_size {
                 hashes[offset + i] = current;
             }
-            // TODO: no unwrap
             current = barretenberg.hash(&current, &current).unwrap();
 
             offset += layer_size;

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -19,16 +19,18 @@ impl Pedersen for Barretenberg {
         left: &FieldElement,
         right: &FieldElement,
     ) -> Result<FieldElement, Error> {
+        use super::FeatureError;
+
         let result_bytes = barretenberg_sys::pedersen::compress_native(
             left.to_be_bytes()
                 .as_slice()
                 .try_into()
-                .map_err(|source| Error::FieldElementSlice { source })?,
+                .map_err(|source| FeatureError::FieldElementSlice { source })?,
             right
                 .to_be_bytes()
                 .as_slice()
                 .try_into()
-                .map_err(|source| Error::FieldElementSlice { source })?,
+                .map_err(|source| FeatureError::FieldElementSlice { source })?,
         );
 
         Ok(FieldElement::from_be_bytes_reduce(&result_bytes))

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -1,56 +1,75 @@
 use acvm::FieldElement;
 
-use super::Barretenberg;
+use super::{Barretenberg, Error};
 
 pub(crate) trait Pedersen {
-    fn compress_native(&self, left: &FieldElement, right: &FieldElement) -> FieldElement;
-    fn compress_many(&self, inputs: Vec<FieldElement>) -> FieldElement;
-    fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement);
+    fn compress_native(
+        &self,
+        left: &FieldElement,
+        right: &FieldElement,
+    ) -> Result<FieldElement, Error>;
+    fn compress_many(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, Error>;
+    fn encrypt(&self, inputs: Vec<FieldElement>) -> Result<(FieldElement, FieldElement), Error>;
 }
 
 #[cfg(feature = "native")]
 impl Pedersen for Barretenberg {
-    fn compress_native(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    fn compress_native(
+        &self,
+        left: &FieldElement,
+        right: &FieldElement,
+    ) -> Result<FieldElement, Error> {
         let result_bytes = barretenberg_sys::pedersen::compress_native(
-            left.to_be_bytes().as_slice().try_into().unwrap(),
-            right.to_be_bytes().as_slice().try_into().unwrap(),
+            left.to_be_bytes()
+                .as_slice()
+                .try_into()
+                .map_err(|source| Error::FieldElementSlice { source })?,
+            right
+                .to_be_bytes()
+                .as_slice()
+                .try_into()
+                .map_err(|source| Error::FieldElementSlice { source })?,
         );
 
-        FieldElement::from_be_bytes_reduce(&result_bytes)
+        Ok(FieldElement::from_be_bytes_reduce(&result_bytes))
     }
 
     #[allow(dead_code)]
-    fn compress_many(&self, inputs: Vec<FieldElement>) -> FieldElement {
+    fn compress_many(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, Error> {
         use super::native::field_to_array;
 
         let mut inputs_buf = Vec::new();
         for f in inputs {
-            inputs_buf.push(field_to_array(&f));
+            inputs_buf.push(field_to_array(&f)?);
         }
         let result_bytes = barretenberg_sys::pedersen::compress_many(&inputs_buf);
 
-        FieldElement::from_be_bytes_reduce(&result_bytes)
+        Ok(FieldElement::from_be_bytes_reduce(&result_bytes))
     }
 
-    fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
+    fn encrypt(&self, inputs: Vec<FieldElement>) -> Result<(FieldElement, FieldElement), Error> {
         use super::native::field_to_array;
 
         let mut inputs_buf = Vec::new();
         for f in inputs {
-            inputs_buf.push(field_to_array(&f));
+            inputs_buf.push(field_to_array(&f)?);
         }
         let (point_x_bytes, point_y_bytes) = barretenberg_sys::pedersen::encrypt(&inputs_buf);
 
         let point_x = FieldElement::from_be_bytes_reduce(&point_x_bytes);
         let point_y = FieldElement::from_be_bytes_reduce(&point_y_bytes);
 
-        (point_x, point_y)
+        Ok((point_x, point_y))
     }
 }
 
 #[cfg(not(feature = "native"))]
 impl Pedersen for Barretenberg {
-    fn compress_native(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
+    fn compress_native(
+        &self,
+        left: &FieldElement,
+        right: &FieldElement,
+    ) -> Result<FieldElement, Error> {
         use super::FIELD_BYTES;
 
         let lhs_ptr: usize = 0;
@@ -63,42 +82,42 @@ impl Pedersen for Barretenberg {
         self.call_multiple(
             "pedersen_plookup_compress_fields",
             vec![&lhs_ptr.into(), &rhs_ptr.into(), &result_ptr.into()],
-        );
+        )?;
 
         let result_bytes: [u8; FIELD_BYTES] = self.read_memory(result_ptr);
-        FieldElement::from_be_bytes_reduce(&result_bytes)
+        Ok(FieldElement::from_be_bytes_reduce(&result_bytes))
     }
 
     #[allow(dead_code)]
-    fn compress_many(&self, inputs: Vec<FieldElement>) -> FieldElement {
+    fn compress_many(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, Error> {
         use super::FIELD_BYTES;
         use crate::barretenberg_structures::Assignments;
 
         let input_buf = Assignments::from(inputs).to_bytes();
-        let input_ptr = self.allocate(&input_buf);
+        let input_ptr = self.allocate(&input_buf)?;
         let result_ptr: usize = 0;
 
         self.call_multiple(
             "pedersen_plookup_compress",
             vec![&input_ptr, &result_ptr.into()],
-        );
+        )?;
 
         let result_bytes: [u8; FIELD_BYTES] = self.read_memory(result_ptr);
-        FieldElement::from_be_bytes_reduce(&result_bytes)
+        Ok(FieldElement::from_be_bytes_reduce(&result_bytes))
     }
 
-    fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
+    fn encrypt(&self, inputs: Vec<FieldElement>) -> Result<(FieldElement, FieldElement), Error> {
         use super::FIELD_BYTES;
         use crate::barretenberg_structures::Assignments;
 
         let input_buf = Assignments::from(inputs).to_bytes();
-        let input_ptr = self.allocate(&input_buf);
+        let input_ptr = self.allocate(&input_buf)?;
         let result_ptr: usize = 0;
 
         self.call_multiple(
             "pedersen_plookup_commit",
             vec![&input_ptr, &result_ptr.into()],
-        );
+        )?;
 
         let result_bytes: [u8; 2 * FIELD_BYTES] = self.read_memory(result_ptr);
         let (point_x_bytes, point_y_bytes) = result_bytes.split_at(FIELD_BYTES);
@@ -106,12 +125,12 @@ impl Pedersen for Barretenberg {
         let point_x = FieldElement::from_be_bytes_reduce(point_x_bytes);
         let point_y = FieldElement::from_be_bytes_reduce(point_y_bytes);
 
-        (point_x, point_y)
+        Ok((point_x, point_y))
     }
 }
 
 #[test]
-fn basic_interop() {
+fn basic_interop() -> Result<(), Error> {
     // Expected values were taken from Barretenberg by running `crypto::pedersen::compress_native`
     // printing the result in hex to `std::cout` and copying
     struct Test<'a> {
@@ -142,17 +161,18 @@ fn basic_interop() {
     for test in tests {
         let expected = FieldElement::from_hex(test.expected_hex).unwrap();
 
-        let got = barretenberg.compress_native(&test.input_left, &test.input_right);
-        let got_many = barretenberg.compress_many(vec![test.input_left, test.input_right]);
+        let got = barretenberg.compress_native(&test.input_left, &test.input_right)?;
+        let got_many = barretenberg.compress_many(vec![test.input_left, test.input_right])?;
         assert_eq!(got, expected);
         assert_eq!(got, got_many);
     }
+    Ok(())
 }
 
 #[test]
-fn pedersen_hash_to_point() {
+fn pedersen_hash_to_point() -> Result<(), Error> {
     let barretenberg = Barretenberg::new();
-    let (x, y) = barretenberg.encrypt(vec![FieldElement::zero(), FieldElement::one()]);
+    let (x, y) = barretenberg.encrypt(vec![FieldElement::zero(), FieldElement::one()])?;
     let expected_x = FieldElement::from_hex(
         "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",
     )
@@ -164,4 +184,5 @@ fn pedersen_hash_to_point() {
 
     assert_eq!(expected_x.to_hex(), x.to_hex());
     assert_eq!(expected_y.to_hex(), y.to_hex());
+    Ok(())
 }

--- a/src/pippenger.rs
+++ b/src/pippenger.rs
@@ -45,7 +45,7 @@ impl Barretenberg {
         self.free(crs_ptr)?;
 
         Ok(Pippenger {
-            pippenger_ptr: pippenger_ptr?.value()?,
+            pippenger_ptr: pippenger_ptr?,
         })
     }
 }

--- a/src/scalar_mul.rs
+++ b/src/scalar_mul.rs
@@ -1,17 +1,17 @@
 use acvm::FieldElement;
 
-use super::{Barretenberg, FIELD_BYTES};
+use super::{Barretenberg, Error, FIELD_BYTES};
 
 pub(crate) trait ScalarMul {
-    fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement);
+    fn fixed_base(&self, input: &FieldElement) -> Result<(FieldElement, FieldElement), Error>;
 }
 
 #[cfg(feature = "native")]
 impl ScalarMul for Barretenberg {
-    fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
+    fn fixed_base(&self, input: &FieldElement) -> Result<(FieldElement, FieldElement), Error> {
         use super::native::field_to_array;
 
-        let result_bytes = barretenberg_sys::schnorr::construct_public_key(&field_to_array(input));
+        let result_bytes = barretenberg_sys::schnorr::construct_public_key(&field_to_array(input)?);
 
         let (pubkey_x_bytes, pubkey_y_bytes) = result_bytes.split_at(FIELD_BYTES);
         assert!(pubkey_x_bytes.len() == FIELD_BYTES);
@@ -19,13 +19,13 @@ impl ScalarMul for Barretenberg {
 
         let pubkey_x = FieldElement::from_be_bytes_reduce(pubkey_x_bytes);
         let pubkey_y = FieldElement::from_be_bytes_reduce(pubkey_y_bytes);
-        (pubkey_x, pubkey_y)
+        Ok((pubkey_x, pubkey_y))
     }
 }
 
 #[cfg(not(feature = "native"))]
 impl ScalarMul for Barretenberg {
-    fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
+    fn fixed_base(&self, input: &FieldElement) -> Result<(FieldElement, FieldElement), Error> {
         let lhs_ptr: usize = 0;
         let result_ptr: usize = lhs_ptr + FIELD_BYTES;
         self.transfer_to_heap(&input.to_be_bytes(), lhs_ptr);
@@ -33,7 +33,7 @@ impl ScalarMul for Barretenberg {
         self.call_multiple(
             "compute_public_key",
             vec![&lhs_ptr.into(), &result_ptr.into()],
-        );
+        )?;
 
         let result_bytes: [u8; 2 * FIELD_BYTES] = self.read_memory(result_ptr);
         let (pubkey_x_bytes, pubkey_y_bytes) = result_bytes.split_at(FIELD_BYTES);
@@ -43,7 +43,7 @@ impl ScalarMul for Barretenberg {
 
         let pubkey_x = FieldElement::from_be_bytes_reduce(pubkey_x_bytes);
         let pubkey_y = FieldElement::from_be_bytes_reduce(pubkey_y_bytes);
-        (pubkey_x, pubkey_y)
+        Ok((pubkey_x, pubkey_y))
     }
 }
 
@@ -51,15 +51,16 @@ impl ScalarMul for Barretenberg {
 mod test {
     use super::*;
     #[test]
-    fn smoke_test() {
+    fn smoke_test() -> Result<(), Error> {
         let barretenberg = Barretenberg::new();
         let input = FieldElement::one();
 
-        let res = barretenberg.fixed_base(&input);
+        let res = barretenberg.fixed_base(&input)?;
         let x = "0000000000000000000000000000000000000000000000000000000000000001";
         let y = "0000000000000002cf135e7506a45d632d270d45f1181294833fc48d823f272c";
 
         assert_eq!(x, res.0.to_hex());
         assert_eq!(y, res.1.to_hex());
+        Ok(())
     }
 }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -140,7 +140,7 @@ impl SchnorrSig for Barretenberg {
         self.transfer_to_heap(sig_e, sig_e_ptr);
         self.transfer_to_heap(message, message_ptr);
 
-        let wasm_value = self.call_multiple(
+        let verified = self.call_multiple(
             "verify_signature",
             vec![
                 &message_ptr.into(),
@@ -153,9 +153,7 @@ impl SchnorrSig for Barretenberg {
 
         // Note, currently for Barretenberg plonk, if the signature fails
         // then the whole circuit fails.
-        let verified = wasm_value.bool()?;
-
-        Ok(verified)
+        Ok(verified.try_into()?)
     }
 }
 

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -40,14 +40,16 @@ impl SchnorrSig for Barretenberg {
         sig: [u8; 64],
         message: &[u8],
     ) -> Result<bool, Error> {
+        use super::FeatureError;
+
         let (sig_s, sig_e) = sig.split_at(32);
 
         let sig_s: [u8; 32] = sig_s
             .try_into()
-            .map_err(|source| Error::SchnorrSlice { source })?;
+            .map_err(|source| FeatureError::SchnorrSlice { source })?;
         let sig_e: [u8; 32] = sig_e
             .try_into()
-            .map_err(|source| Error::SchnorrSlice { source })?;
+            .map_err(|source| FeatureError::SchnorrSlice { source })?;
 
         Ok(barretenberg_sys::schnorr::verify_signature(
             pub_key, sig_s, sig_e, message,

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -153,7 +153,9 @@ impl SchnorrSig for Barretenberg {
 
         // Note, currently for Barretenberg plonk, if the signature fails
         // then the whole circuit fails.
-        wasm_value.bool()
+        let verified = wasm_value.bool()?;
+
+        Ok(verified)
     }
 }
 

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -113,7 +113,7 @@ impl SchnorrSig for Barretenberg {
             vec![&private_key_ptr.into(), &result_ptr.into()],
         )?;
 
-        self.read_memory(result_ptr)
+        Ok(self.read_memory(result_ptr))
     }
 
     fn verify_signature(


### PR DESCRIPTION
This reworks the backend to leverage the changes for fallible functions. It introduces an error enum with admittedly bad variant names and uses them to map error cases throughout the codebase so panic and/or unwrap isn't used to handle most values.

~~There are still some TODOs to cleanup even more `unwrap` cases and it relies on something like https://github.com/noir-lang/acvm/pull/251, but this should be a solid skeleton for how a backend can surface errors to nargo.~~

Closes #159 