### PR TITLE
chore: use `WASMValue` for wasm arguments as well as return values

### DIFF
--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -36,7 +36,6 @@ impl SmartContract for Barretenberg {
 impl SmartContract for Barretenberg {
     fn eth_contract_from_vk(&self, verification_key: &[u8]) -> String {
         use crate::wasm::POINTER_BYTES;
-        use wasmer::Value;
 
         let g2 = G2::new();
 
@@ -50,7 +49,7 @@ impl SmartContract for Barretenberg {
         let contract_size = self
             .call_multiple(
                 "acir_proofs_get_solidity_verifier",
-                vec![&g2_ptr, &vk_ptr, &Value::I32(contract_ptr_ptr as i32)],
+                vec![&g2_ptr, &vk_ptr, &contract_ptr_ptr.into()],
             )
             .value();
         let contract_size: usize = contract_size.unwrap_i32() as usize;

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -52,7 +52,6 @@ impl Pedersen for Barretenberg {
 impl Pedersen for Barretenberg {
     fn compress_native(&self, left: &FieldElement, right: &FieldElement) -> FieldElement {
         use super::FIELD_BYTES;
-        use wasmer::Value;
 
         let lhs_ptr: usize = 0;
         let rhs_ptr: usize = lhs_ptr + FIELD_BYTES;
@@ -63,11 +62,7 @@ impl Pedersen for Barretenberg {
 
         self.call_multiple(
             "pedersen_plookup_compress_fields",
-            vec![
-                &Value::I32(lhs_ptr as i32),
-                &Value::I32(rhs_ptr as i32),
-                &Value::I32(result_ptr as i32),
-            ],
+            vec![&lhs_ptr.into(), &rhs_ptr.into(), &result_ptr.into()],
         );
 
         let result_bytes = self.slice_memory(result_ptr, FIELD_BYTES);
@@ -78,7 +73,6 @@ impl Pedersen for Barretenberg {
     fn compress_many(&self, inputs: Vec<FieldElement>) -> FieldElement {
         use super::FIELD_BYTES;
         use crate::barretenberg_structures::Assignments;
-        use wasmer::Value;
 
         let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf);
@@ -86,7 +80,7 @@ impl Pedersen for Barretenberg {
 
         self.call_multiple(
             "pedersen_plookup_compress",
-            vec![&input_ptr, &Value::I32(result_ptr as i32)],
+            vec![&input_ptr, &result_ptr.into()],
         );
 
         let result_bytes = self.slice_memory(result_ptr, FIELD_BYTES);
@@ -96,7 +90,6 @@ impl Pedersen for Barretenberg {
     fn encrypt(&self, inputs: Vec<FieldElement>) -> (FieldElement, FieldElement) {
         use super::FIELD_BYTES;
         use crate::barretenberg_structures::Assignments;
-        use wasmer::Value;
 
         let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf);
@@ -104,7 +97,7 @@ impl Pedersen for Barretenberg {
 
         self.call_multiple(
             "pedersen_plookup_commit",
-            vec![&input_ptr, &Value::I32(result_ptr as i32)],
+            vec![&input_ptr, &result_ptr.into()],
         );
 
         let result_bytes = self.slice_memory(result_ptr, 2 * FIELD_BYTES);

--- a/src/pippenger.rs
+++ b/src/pippenger.rs
@@ -4,7 +4,7 @@ pub(crate) struct Pippenger {
     #[cfg(feature = "native")]
     pippenger_ptr: *mut std::os::raw::c_void,
     #[cfg(not(feature = "native"))]
-    pippenger_ptr: wasmer::Value,
+    pippenger_ptr: crate::wasm::WASMValue,
 }
 
 #[cfg(feature = "native")]
@@ -16,7 +16,7 @@ impl Pippenger {
 
 #[cfg(not(feature = "native"))]
 impl Pippenger {
-    pub(crate) fn pointer(&self) -> wasmer::Value {
+    pub(crate) fn pointer(&self) -> crate::wasm::WASMValue {
         self.pippenger_ptr.clone()
     }
 }
@@ -34,18 +34,12 @@ impl Barretenberg {
 impl Barretenberg {
     pub(crate) fn get_pippenger(&self, crs_data: &[u8]) -> Pippenger {
         use super::FIELD_BYTES;
-        use wasmer::Value;
 
         let num_points = crs_data.len() / (2 * FIELD_BYTES);
 
         let crs_ptr = self.allocate(crs_data);
 
-        let pippenger_ptr = self
-            .call_multiple(
-                "new_pippenger",
-                vec![&crs_ptr, &Value::I32(num_points as i32)],
-            )
-            .value();
+        let pippenger_ptr = self.call_multiple("new_pippenger", vec![&crs_ptr, &num_points.into()]);
 
         self.free(crs_ptr);
 

--- a/src/scalar_mul.rs
+++ b/src/scalar_mul.rs
@@ -26,15 +26,13 @@ impl ScalarMul for Barretenberg {
 #[cfg(not(feature = "native"))]
 impl ScalarMul for Barretenberg {
     fn fixed_base(&self, input: &FieldElement) -> (FieldElement, FieldElement) {
-        use wasmer::Value;
-
         let lhs_ptr: usize = 0;
         let result_ptr: usize = lhs_ptr + FIELD_BYTES;
         self.transfer_to_heap(&input.to_be_bytes(), lhs_ptr);
 
         self.call_multiple(
             "compute_public_key",
-            vec![&Value::I32(lhs_ptr as i32), &Value::I32(result_ptr as i32)],
+            vec![&lhs_ptr.into(), &result_ptr.into()],
         );
 
         let result_bytes = self.slice_memory(result_ptr, 2 * FIELD_BYTES);

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -36,7 +36,6 @@ impl SchnorrSig for Barretenberg {
 impl SchnorrSig for Barretenberg {
     fn construct_signature(&self, message: &[u8], private_key: [u8; 32]) -> [u8; 64] {
         use super::{wasm::WASM_SCRATCH_BYTES, FIELD_BYTES};
-        use wasmer::Value;
 
         let sig_s_ptr: usize = 0;
         let sig_e_ptr: usize = sig_s_ptr + FIELD_BYTES;
@@ -52,11 +51,11 @@ impl SchnorrSig for Barretenberg {
         self.call_multiple(
             "construct_signature",
             vec![
-                &Value::I32(message_ptr as i32),
-                &Value::I32(message.len() as i32),
-                &Value::I32(private_key_ptr as i32),
-                &Value::I32(sig_s_ptr as i32),
-                &Value::I32(sig_e_ptr as i32),
+                &message_ptr.into(),
+                &message.len().into(),
+                &private_key_ptr.into(),
+                &sig_s_ptr.into(),
+                &sig_e_ptr.into(),
             ],
         );
 
@@ -72,7 +71,6 @@ impl SchnorrSig for Barretenberg {
     #[allow(dead_code)]
     fn construct_public_key(&self, private_key: [u8; 32]) -> [u8; 64] {
         use super::FIELD_BYTES;
-        use wasmer::Value;
 
         let private_key_ptr: usize = 0;
         let result_ptr: usize = private_key_ptr + FIELD_BYTES;
@@ -81,10 +79,7 @@ impl SchnorrSig for Barretenberg {
 
         self.call_multiple(
             "compute_public_key",
-            vec![
-                &Value::I32(private_key_ptr as i32),
-                &Value::I32(result_ptr as i32),
-            ],
+            vec![&private_key_ptr.into(), &result_ptr.into()],
         );
 
         self.slice_memory(result_ptr, 2 * FIELD_BYTES)
@@ -94,7 +89,6 @@ impl SchnorrSig for Barretenberg {
 
     fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {
         use super::{wasm::WASM_SCRATCH_BYTES, FIELD_BYTES};
-        use wasmer::Value;
 
         let (sig_s, sig_e) = sig.split_at(FIELD_BYTES);
 
@@ -115,19 +109,15 @@ impl SchnorrSig for Barretenberg {
         let wasm_value = self.call_multiple(
             "verify_signature",
             vec![
-                &Value::I32(message_ptr as i32),
-                &Value::I32(message.len() as i32),
-                &Value::I32(public_key_ptr as i32),
-                &Value::I32(sig_s_ptr as i32),
-                &Value::I32(sig_e_ptr as i32),
+                &message_ptr.into(),
+                &message.len().into(),
+                &public_key_ptr.into(),
+                &sig_s_ptr.into(),
+                &sig_e_ptr.into(),
             ],
         );
-        match wasm_value.into_i32() {
-            0 => false,
-            1 => true,
-            _=> unreachable!("verify signature should return a boolean to indicate whether the signature + parameters were valid")
-        }
 
+        wasm_value.bool()
         // Note, currently for Barretenberg plonk, if the signature fails
         // then the whole circuit fails.
     }


### PR DESCRIPTION
This PR splits off @phated's change from https://github.com/noir-lang/aztec_backend/pull/151 to use `WASMValue` for wasm arguments as well as for return values. 