### PR TITLE
chore: Enforce proper conversion of memory into fixed length array

### DIFF
--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -57,7 +57,7 @@ impl SmartContract for Barretenberg {
         // We then need to read the pointer at `contract_ptr_ptr` to get the smart contract's location
         // and then slice memory again at `contract_ptr_ptr` to get the smart contract string.
         let contract_ptr: [u8; POINTER_BYTES] = self.read_memory(contract_ptr_ptr);
-        let contract_ptr: usize = u32::from_le_bytes(contract_ptr.try_into().unwrap()) as usize;
+        let contract_ptr: usize = u32::from_le_bytes(contract_ptr) as usize;
 
         let sc_as_bytes = self.read_memory_variable_length(contract_ptr, contract_size);
 

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -56,7 +56,7 @@ impl SmartContract for Barretenberg {
 
         // We then need to read the pointer at `contract_ptr_ptr` to get the smart contract's location
         // and then slice memory again at `contract_ptr_ptr` to get the smart contract string.
-        let contract_ptr: [u8; POINTER_BYTES] = self.slice_memory(contract_ptr_ptr);
+        let contract_ptr: [u8; POINTER_BYTES] = self.read_memory(contract_ptr_ptr);
         let contract_ptr: usize = u32::from_le_bytes(contract_ptr.try_into().unwrap()) as usize;
 
         let sc_as_bytes = self.read_memory_variable_length(contract_ptr, contract_size);

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -56,11 +56,10 @@ impl SmartContract for Barretenberg {
 
         // We then need to read the pointer at `contract_ptr_ptr` to get the smart contract's location
         // and then slice memory again at `contract_ptr_ptr` to get the smart contract string.
-        let contract_ptr = self.slice_memory(contract_ptr_ptr, POINTER_BYTES);
-        let contract_ptr: usize =
-            u32::from_le_bytes(contract_ptr[0..POINTER_BYTES].try_into().unwrap()) as usize;
+        let contract_ptr: [u8; POINTER_BYTES] = self.slice_memory(contract_ptr_ptr);
+        let contract_ptr: usize = u32::from_le_bytes(contract_ptr.try_into().unwrap()) as usize;
 
-        let sc_as_bytes = self.slice_memory(contract_ptr, contract_size);
+        let sc_as_bytes = self.read_memory_variable_length(contract_ptr, contract_size);
 
         let verification_key_library: String = sc_as_bytes.iter().map(|b| *b as char).collect();
         format!("{verification_key_library}{ULTRA_VERIFIER_CONTRACT}")

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -254,7 +254,7 @@ impl Composer for Barretenberg {
         // We then need to read the pointer at `pk_ptr_ptr` to get the key's location
         // and then slice memory again at `pk_ptr` to get the proving key.
         let pk_ptr: [u8; POINTER_BYTES] = self.read_memory(pk_ptr_ptr);
-        let pk_ptr: usize = u32::from_le_bytes(pk_ptr.try_into().unwrap()) as usize;
+        let pk_ptr: usize = u32::from_le_bytes(pk_ptr) as usize;
 
         self.read_memory_variable_length(pk_ptr, pk_size)
     }
@@ -290,7 +290,7 @@ impl Composer for Barretenberg {
         // We then need to read the pointer at `vk_ptr_ptr` to get the key's location
         // and then slice memory again at `vk_ptr` to get the verification key.
         let vk_ptr: [u8; POINTER_BYTES] = self.read_memory(vk_ptr_ptr);
-        let vk_ptr: usize = u32::from_le_bytes(vk_ptr.try_into().unwrap()) as usize;
+        let vk_ptr: usize = u32::from_le_bytes(vk_ptr) as usize;
 
         self.read_memory_variable_length(vk_ptr, vk_size)
     }
@@ -338,7 +338,7 @@ impl Composer for Barretenberg {
         // We then need to read the pointer at `proof_ptr_ptr` to get the proof's location
         // and then slice memory again at `proof_ptr` to get the proof data.
         let proof_ptr: [u8; POINTER_BYTES] = self.read_memory(proof_ptr_ptr);
-        let proof_ptr: usize = u32::from_le_bytes(proof_ptr.try_into().unwrap()) as usize;
+        let proof_ptr: usize = u32::from_le_bytes(proof_ptr) as usize;
 
         let result = self.read_memory_variable_length(proof_ptr, proof_size);
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -338,8 +338,7 @@ impl Composer for Barretenberg {
         // We then need to read the pointer at `proof_ptr_ptr` to get the proof's location
         // and then slice memory again at `proof_ptr` to get the proof data.
         let proof_ptr: [u8; POINTER_BYTES] = self.read_memory(proof_ptr_ptr);
-        let proof_ptr: usize =
-            u32::from_le_bytes(proof_ptr[0..POINTER_BYTES].try_into().unwrap()) as usize;
+        let proof_ptr: usize = u32::from_le_bytes(proof_ptr.try_into().unwrap()) as usize;
 
         let result = self.read_memory_variable_length(proof_ptr, proof_size);
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -253,7 +253,7 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `pk_ptr_ptr` to get the key's location
         // and then slice memory again at `pk_ptr` to get the proving key.
-        let pk_ptr: [u8; POINTER_BYTES] = self.slice_memory(pk_ptr_ptr);
+        let pk_ptr: [u8; POINTER_BYTES] = self.read_memory(pk_ptr_ptr);
         let pk_ptr: usize = u32::from_le_bytes(pk_ptr.try_into().unwrap()) as usize;
 
         self.read_memory_variable_length(pk_ptr, pk_size)
@@ -289,7 +289,7 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `vk_ptr_ptr` to get the key's location
         // and then slice memory again at `vk_ptr` to get the verification key.
-        let vk_ptr: [u8; POINTER_BYTES] = self.slice_memory(vk_ptr_ptr);
+        let vk_ptr: [u8; POINTER_BYTES] = self.read_memory(vk_ptr_ptr);
         let vk_ptr: usize = u32::from_le_bytes(vk_ptr.try_into().unwrap()) as usize;
 
         self.read_memory_variable_length(vk_ptr, vk_size)
@@ -337,7 +337,7 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `proof_ptr_ptr` to get the proof's location
         // and then slice memory again at `proof_ptr` to get the proof data.
-        let proof_ptr: [u8; POINTER_BYTES] = self.slice_memory(proof_ptr_ptr);
+        let proof_ptr: [u8; POINTER_BYTES] = self.read_memory(proof_ptr_ptr);
         let proof_ptr: usize =
             u32::from_le_bytes(proof_ptr[0..POINTER_BYTES].try_into().unwrap()) as usize;
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -253,11 +253,10 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `pk_ptr_ptr` to get the key's location
         // and then slice memory again at `pk_ptr` to get the proving key.
-        let pk_ptr = self.slice_memory(pk_ptr_ptr, POINTER_BYTES);
-        let pk_ptr: usize =
-            u32::from_le_bytes(pk_ptr[0..POINTER_BYTES].try_into().unwrap()) as usize;
+        let pk_ptr: [u8; POINTER_BYTES] = self.slice_memory(pk_ptr_ptr);
+        let pk_ptr: usize = u32::from_le_bytes(pk_ptr.try_into().unwrap()) as usize;
 
-        self.slice_memory(pk_ptr, pk_size)
+        self.read_memory_variable_length(pk_ptr, pk_size)
     }
 
     fn compute_verification_key(
@@ -290,11 +289,10 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `vk_ptr_ptr` to get the key's location
         // and then slice memory again at `vk_ptr` to get the verification key.
-        let vk_ptr = self.slice_memory(vk_ptr_ptr, POINTER_BYTES);
-        let vk_ptr: usize =
-            u32::from_le_bytes(vk_ptr[0..POINTER_BYTES].try_into().unwrap()) as usize;
+        let vk_ptr: [u8; POINTER_BYTES] = self.slice_memory(vk_ptr_ptr);
+        let vk_ptr: usize = u32::from_le_bytes(vk_ptr.try_into().unwrap()) as usize;
 
-        self.slice_memory(vk_ptr, vk_size)
+        self.read_memory_variable_length(vk_ptr, vk_size)
     }
 
     fn create_proof_with_pk(
@@ -339,11 +337,11 @@ impl Composer for Barretenberg {
 
         // We then need to read the pointer at `proof_ptr_ptr` to get the proof's location
         // and then slice memory again at `proof_ptr` to get the proof data.
-        let proof_ptr = self.slice_memory(proof_ptr_ptr, POINTER_BYTES);
+        let proof_ptr: [u8; POINTER_BYTES] = self.slice_memory(proof_ptr_ptr);
         let proof_ptr: usize =
             u32::from_le_bytes(proof_ptr[0..POINTER_BYTES].try_into().unwrap()) as usize;
 
-        let result = self.slice_memory(proof_ptr, proof_size);
+        let result = self.read_memory_variable_length(proof_ptr, proof_size);
 
         // Barretenberg returns proofs which are prepended with the public inputs.
         // This behavior is nonstandard so we strip the public inputs from the proof.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,7 @@ mod wasm {
             }
         }
 
-        // XXX: change to read_mem
-        pub(super) fn slice_memory<const SIZE: usize>(&self, start: usize) -> [u8; SIZE] {
+        pub(super) fn read_memory<const SIZE: usize>(&self, start: usize) -> [u8; SIZE] {
             self.read_memory_variable_length(start, SIZE)
                 .try_into()
                 .expect("Read memory should be of the specified length")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,12 +169,18 @@ mod wasm {
         }
 
         // XXX: change to read_mem
-        pub(super) fn slice_memory(&self, start: usize, length: usize) -> Vec<u8> {
+        pub(super) fn slice_memory<const SIZE: usize>(&self, start: usize) -> [u8; SIZE] {
+            self.read_memory_variable_length(start, SIZE)
+                .try_into()
+                .expect("Read memory should be of the specified length")
+        }
+
+        pub(super) fn read_memory_variable_length(&self, start: usize, length: usize) -> Vec<u8> {
             let memory = &self.memory;
             let end = start + length;
 
             #[cfg(feature = "js")]
-            return memory.uint8view().to_vec()[start as usize..end].to_vec();
+            return memory.uint8view().to_vec()[start..end].to_vec();
 
             #[cfg(not(feature = "js"))]
             return memory.view()[start..end]

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -65,7 +65,7 @@ impl Pedersen for Barretenberg {
             vec![&lhs_ptr.into(), &rhs_ptr.into(), &result_ptr.into()],
         );
 
-        let result_bytes: [u8; FIELD_BYTES] = self.slice_memory(result_ptr);
+        let result_bytes: [u8; FIELD_BYTES] = self.read_memory(result_ptr);
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 
@@ -83,7 +83,7 @@ impl Pedersen for Barretenberg {
             vec![&input_ptr, &result_ptr.into()],
         );
 
-        let result_bytes: [u8; FIELD_BYTES] = self.slice_memory(result_ptr);
+        let result_bytes: [u8; FIELD_BYTES] = self.read_memory(result_ptr);
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 
@@ -100,7 +100,7 @@ impl Pedersen for Barretenberg {
             vec![&input_ptr, &result_ptr.into()],
         );
 
-        let result_bytes: [u8; 2 * FIELD_BYTES] = self.slice_memory(result_ptr);
+        let result_bytes: [u8; 2 * FIELD_BYTES] = self.read_memory(result_ptr);
         let (point_x_bytes, point_y_bytes) = result_bytes.split_at(FIELD_BYTES);
 
         let point_x = FieldElement::from_be_bytes_reduce(point_x_bytes);

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -65,7 +65,7 @@ impl Pedersen for Barretenberg {
             vec![&lhs_ptr.into(), &rhs_ptr.into(), &result_ptr.into()],
         );
 
-        let result_bytes = self.slice_memory(result_ptr, FIELD_BYTES);
+        let result_bytes: [u8; FIELD_BYTES] = self.slice_memory(result_ptr);
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 
@@ -83,7 +83,7 @@ impl Pedersen for Barretenberg {
             vec![&input_ptr, &result_ptr.into()],
         );
 
-        let result_bytes = self.slice_memory(result_ptr, FIELD_BYTES);
+        let result_bytes: [u8; FIELD_BYTES] = self.slice_memory(result_ptr);
         FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 
@@ -100,7 +100,7 @@ impl Pedersen for Barretenberg {
             vec![&input_ptr, &result_ptr.into()],
         );
 
-        let result_bytes = self.slice_memory(result_ptr, 2 * FIELD_BYTES);
+        let result_bytes: [u8; 2 * FIELD_BYTES] = self.slice_memory(result_ptr);
         let (point_x_bytes, point_y_bytes) = result_bytes.split_at(FIELD_BYTES);
 
         let point_x = FieldElement::from_be_bytes_reduce(point_x_bytes);

--- a/src/scalar_mul.rs
+++ b/src/scalar_mul.rs
@@ -35,7 +35,7 @@ impl ScalarMul for Barretenberg {
             vec![&lhs_ptr.into(), &result_ptr.into()],
         );
 
-        let result_bytes = self.slice_memory(result_ptr, 2 * FIELD_BYTES);
+        let result_bytes: [u8; 2 * FIELD_BYTES] = self.slice_memory(result_ptr);
         let (pubkey_x_bytes, pubkey_y_bytes) = result_bytes.split_at(FIELD_BYTES);
 
         assert!(pubkey_x_bytes.len() == FIELD_BYTES);

--- a/src/scalar_mul.rs
+++ b/src/scalar_mul.rs
@@ -35,7 +35,7 @@ impl ScalarMul for Barretenberg {
             vec![&lhs_ptr.into(), &result_ptr.into()],
         );
 
-        let result_bytes: [u8; 2 * FIELD_BYTES] = self.slice_memory(result_ptr);
+        let result_bytes: [u8; 2 * FIELD_BYTES] = self.read_memory(result_ptr);
         let (pubkey_x_bytes, pubkey_y_bytes) = result_bytes.split_at(FIELD_BYTES);
 
         assert!(pubkey_x_bytes.len() == FIELD_BYTES);

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -59,8 +59,8 @@ impl SchnorrSig for Barretenberg {
             ],
         );
 
-        let sig_s: [u8; FIELD_BYTES] = self.slice_memory(sig_s_ptr);
-        let sig_e: [u8; FIELD_BYTES] = self.slice_memory(sig_e_ptr);
+        let sig_s: [u8; FIELD_BYTES] = self.read_memory(sig_s_ptr);
+        let sig_e: [u8; FIELD_BYTES] = self.read_memory(sig_e_ptr);
 
         let sig_bytes: [u8; 64] = [sig_s, sig_e].concat().try_into().unwrap();
         sig_bytes
@@ -80,7 +80,7 @@ impl SchnorrSig for Barretenberg {
             vec![&private_key_ptr.into(), &result_ptr.into()],
         );
 
-        self.slice_memory(result_ptr)
+        self.read_memory(result_ptr)
     }
 
     fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -59,10 +59,8 @@ impl SchnorrSig for Barretenberg {
             ],
         );
 
-        let sig_s_bytes = self.slice_memory(sig_s_ptr, FIELD_BYTES);
-        let sig_e_bytes = self.slice_memory(sig_e_ptr, FIELD_BYTES);
-        let sig_s: [u8; 32] = sig_s_bytes.try_into().unwrap();
-        let sig_e: [u8; 32] = sig_e_bytes.try_into().unwrap();
+        let sig_s: [u8; FIELD_BYTES] = self.slice_memory(sig_s_ptr);
+        let sig_e: [u8; FIELD_BYTES] = self.slice_memory(sig_e_ptr);
 
         let sig_bytes: [u8; 64] = [sig_s, sig_e].concat().try_into().unwrap();
         sig_bytes
@@ -82,9 +80,7 @@ impl SchnorrSig for Barretenberg {
             vec![&private_key_ptr.into(), &result_ptr.into()],
         );
 
-        self.slice_memory(result_ptr, 2 * FIELD_BYTES)
-            .try_into()
-            .unwrap()
+        self.slice_memory(result_ptr)
     }
 
     fn verify_signature(&self, pub_key: [u8; 64], sig: [u8; 64], message: &[u8]) -> bool {


### PR DESCRIPTION
Addresses review comment https://github.com/noir-lang/aztec_backend/pull/151#discussion_r1185926029.

A lot of our type issues were due to `slice_memory` returning a `&[u8]` whereas we want a fixed length array. This leads to us having more information than the compiler and so need to `try_into().unwrap()` in a lot of places.

I've fixed this by giving the compiler more hints about what we want returned from `slice_memory`, it's now generic with a const parameter `SIZE` and will return a `[u8; SIZE]` array. We no longer pass a length argument but will often have to provide a type hint when calling the function.

This isn't always usable for all situations where we need to read from memory (as we don't always know the length of the array at compile time. I've then added `read_memory_variable_length()` which has the current behaviour of `slice_memory` 