### PR TITLE
chore: add `SchnorrSignature` struct

### DIFF
--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -100,7 +100,7 @@ impl PartialWitnessGenerator for Barretenberg {
                     message.push(msg_i);
                 }
 
-                let valid_signature = self.verify_signature(pub_key, signature, &message);
+                let valid_signature = self.verify_signature(pub_key, signature.into(), &message);
                 if !valid_signature {
                     dbg!("signature has failed to verify");
                 }


### PR DESCRIPTION
This helps avoid us having to merge and split the signature element arrays a couple of times, avoiding the situation where `SchnorrConvert` is thrown in #151. It also motivates removal of the `SchnorrSlice`  error variant .